### PR TITLE
Feature/MP-609 file references as strings

### DIFF
--- a/api/sqlsol/Tables.spec
+++ b/api/sqlsol/Tables.spec
@@ -40,21 +40,13 @@
         "name": "execution_process_instance",
         "type": "address"
       },
-      "hoard_address": {
-        "name": "hoard_address",
-        "type": "bytes32"
+      "hoardRefPrivateParameters": {
+        "name": "hoard_ref_private_parameters",
+        "type": "string"
       },
-      "hoard_secret": {
-        "name": "hoard_secret",
-        "type": "bytes32"
-      },
-      "event_log_hoard_address": {
-        "name": "event_log_hoard_address",
-        "type": "bytes32"
-      },
-      "event_log_hoard_secret": {
-        "name": "event_log_hoard_secret",
-        "type": "bytes32"
+      "hoardRefEventLog": {
+        "name": "hoard_ref_event_log",
+        "type": "string"
       }
     }
   },

--- a/api/sqlsol/Tables.spec
+++ b/api/sqlsol/Tables.spec
@@ -272,23 +272,19 @@
     "TableName": "ARCHETYPE_DOCUMENTS",
     "Filter": "Log1Text = 'AN://archetype/documents'",
     "Columns": {
-      "archetype_address": {
+      "archetypeAddress": {
         "name": "archetype_address",
         "type": "address",
         "primary": true
       },
-      "document_key": {
+      "documentKey": {
         "name": "document_key",
-        "type": "bytes32",
+        "type": "string",
         "primary": true
       },
-      "hoard_address": {
-        "name": "hoard_address",
-        "type": "bytes32"
-      },
-      "secret_key": {
-        "name": "secret_key",
-        "type": "bytes32"
+      "documentReference": {
+        "name": "document_reference",
+        "type": "string"
       }
     }
   },

--- a/api/sqlsol/Tables.spec
+++ b/api/sqlsol/Tables.spec
@@ -40,12 +40,12 @@
         "name": "execution_process_instance",
         "type": "address"
       },
-      "hoardRefPrivateParameters": {
-        "name": "hoard_ref_private_parameters",
+      "privateParametersFileReference": {
+        "name": "private_parameters_file_reference",
         "type": "string"
       },
-      "hoardRefEventLog": {
-        "name": "hoard_ref_event_log",
+      "eventLogFileReference": {
+        "name": "event_log_file_reference",
         "type": "string"
       }
     }

--- a/api/sqlsol/Tables.spec
+++ b/api/sqlsol/Tables.spec
@@ -523,13 +523,9 @@
         "name": "active",
         "type": "bool"
       },
-      "diagram_address": {
-        "name": "diagram_address",
-        "type": "bytes32"
-      },
-      "diagram_secret": {
-        "name": "diagram_secret",
-        "type": "bytes32"
+      "modelFileReference": {
+        "name": "model_file_reference",
+        "type": "string"
       }
     }
   },

--- a/contracts/src/agreements/ActiveAgreement.sol
+++ b/contracts/src/agreements/ActiveAgreement.sol
@@ -64,29 +64,22 @@ contract ActiveAgreement is Named, DataStorage, AddressScopes, Signable, EventEm
 	function setMaxNumberOfEvents(uint32 _maxNumberOfEvents) external;
 
 	/**
-	 * @dev Returns the Hoard Address
-	 * @return the Hoard Address
+	 * @dev Returns the reference to the private parameters of this ActiveAgreement
+	 * @return the reference to an external document containing private parameters
 	 */
-	function getHoardAddress() external view returns (bytes32);
-
+	function getPrivateParametersReference() external view returns (string);
 
 	/**
-	 * @dev Returns the Hoard Secret
-	 * @return the Hoard Secret
+	 * @dev Updates the Hoard reference for the event log of this agreement
+	 * @param _hoardRefEventLog the reference to the event log in Hoard
 	 */
-	function getHoardSecret() external view returns (bytes32);
-
-
-	/**
-	 * @dev Sets the Hoard Address and Hoard Secret for the Event Log
-	 */
-	function setEventLogReference(bytes32 _eventLogHoardAddress, bytes32 _eventLogHoardSecret) external;
+	function setEventLogReference(string _hoardRefEventLog) external;
 
 	/**
-	 * @dev Returns the Hoard Address and Hoard Secret for the Event Log
-	 * @return the Hoard Address and Hoard Secret for the Event Log
+	 * @dev Returns the reference for the event log of this ActiveAgreement
+	 * @return the Hoard reference for the event log of this agreement
 	 */
-	function getEventLogReference() external view returns (bytes32 hoardAddress, bytes32 hoardSecret);
+	function getEventLogReference() external view returns (string);
 
 	/**
 	 * @dev Returns the max number of events for the event log

--- a/contracts/src/agreements/ActiveAgreement.sol
+++ b/contracts/src/agreements/ActiveAgreement.sol
@@ -70,14 +70,14 @@ contract ActiveAgreement is Named, DataStorage, AddressScopes, Signable, EventEm
 	function getPrivateParametersReference() external view returns (string);
 
 	/**
-	 * @dev Updates the Hoard reference for the event log of this agreement
-	 * @param _hoardRefEventLog the reference to the event log in Hoard
+	 * @dev Updates the file reference for the event log of this agreement
+	 * @param _eventLogFileReference the file reference to the event log
 	 */
-	function setEventLogReference(string _hoardRefEventLog) external;
+	function setEventLogReference(string _eventLogFileReference) external;
 
 	/**
 	 * @dev Returns the reference for the event log of this ActiveAgreement
-	 * @return the Hoard reference for the event log of this agreement
+	 * @return the file reference for the event log of this agreement
 	 */
 	function getEventLogReference() external view returns (string);
 

--- a/contracts/src/agreements/ActiveAgreementRegistry.sol
+++ b/contracts/src/agreements/ActiveAgreementRegistry.sol
@@ -30,8 +30,8 @@ contract ActiveAgreementRegistry is EventListener, ProcessStateChangeListener, U
 		uint32 max_event_count,
 		address	formation_process_instance,
 		address	execution_process_instance,
-		string hoardRefPrivateParameters,
-		string hoardRefEventLog
+		string privateParametersFileReference,
+		string eventLogFileReference
 	);
 
 	event LogAgreementFormationProcessUpdate(
@@ -55,7 +55,7 @@ contract ActiveAgreementRegistry is EventListener, ProcessStateChangeListener, U
 	event LogAgreementEventLogReference(
 		bytes32 indexed eventId,
 		address agreement_address, 
-		string hoardRefEventLog
+		string eventLogFileReference
 	);
 
 	event LogAgreementCollectionCreation(
@@ -109,7 +109,7 @@ contract ActiveAgreementRegistry is EventListener, ProcessStateChangeListener, U
 	 * @param _archetype archetype
 	 * @param _name name
 	 * @param _creator address
-	 * @param _hoardRefPrivateParameters reference of the private parametes of this agreement in Hoard
+	 * @param _privateParametersFileReference the file reference of the private parametes of this agreement
 	 * @param _isPrivate agreement is private
 	 * @param _parties parties array
 	 * @param _collectionId id of agreement collection (optional)
@@ -120,7 +120,7 @@ contract ActiveAgreementRegistry is EventListener, ProcessStateChangeListener, U
 		address _archetype,
 		string _name, 
 		address _creator, 
-		string _hoardRefPrivateParameters,
+		string _privateParametersFileReference,
 		bool _isPrivate,
 		address[] _parties, 
 		bytes32 _collectionId, 
@@ -204,15 +204,15 @@ contract ActiveAgreementRegistry is EventListener, ProcessStateChangeListener, U
 	 * @return archetype - the agreement's archetype adress
 	 * @return name - the name of the agreement
 	 * @return creator - the creator of the agreement
-	 * @return hoardRefPrivateParameters - reference to the agreement parameters in Hoard (only used when agreement is private)
-	 * @return hoardRefEventLog - address of the agreement's event log in Hoard
+	 * @return privateParametersFileReference - the file reference to the private agreement parameters (only used when agreement is private)
+	 * @return eventLogFileReference - the file reference to the agreement's event log
 	 * @return maxNumberOfEvents - the maximum number of events allowed to be stored for this agreement
-	 * @return isPrivate - whether the agreement's parameters are private, i.e. stored off-chain in hoard
+	 * @return isPrivate - whether there are private agreement parameters, i.e. stored off-chain
 	 * @return legalState - the agreement's Agreement.LegalState as uint8
 	 * @return formationProcessInstance - the address of the process instance representing the formation of this agreement
 	 * @return executionProcessInstance - the address of the process instance representing the execution of this agreement
 	 */
-	function getActiveAgreementData(address _activeAgreement) external view returns (address archetype, string name, address creator, string hoardRefPrivateParameters, string hoardRefEventLog, uint maxNumberOfEvents, bool isPrivate, uint8 legalState, address formationProcessInstance, address executionProcessInstance);
+	function getActiveAgreementData(address _activeAgreement) external view returns (address archetype, string name, address creator, string privateParametersFileReference, string eventLogFileReference, uint maxNumberOfEvents, bool isPrivate, uint8 legalState, address formationProcessInstance, address executionProcessInstance);
 
     /**
 	 * @dev Returns the number of agreement parameter entries.
@@ -252,11 +252,11 @@ contract ActiveAgreementRegistry is EventListener, ProcessStateChangeListener, U
 	function getPartyByActiveAgreementData(address _activeAgreement, address _party) external view returns (address signedBy, uint signatureTimestamp);
 
 	/**
-	 * @dev Updates the Hoard reference for the event log of the specified agreement
+	 * @dev Updates the file reference for the event log of the specified agreement
 	 * @param _activeAgreement the address of active agreement
-	 * @param _hoardRefEventLog a hoard reference of the event log of this agreement
+	 * @param _eventLogFileReference the file reference of the event log of this agreement
 	 */
-	 function setEventLogReference(address _activeAgreement, string _hoardRefEventLog) external;
+	 function setEventLogReference(address _activeAgreement, string _eventLogFileReference) external;
 
 	/**
 	 * @dev Creates a new agreement collection

--- a/contracts/src/agreements/ActiveAgreementRegistry.sol
+++ b/contracts/src/agreements/ActiveAgreementRegistry.sol
@@ -30,10 +30,8 @@ contract ActiveAgreementRegistry is EventListener, ProcessStateChangeListener, U
 		uint32 max_event_count,
 		address	formation_process_instance,
 		address	execution_process_instance,
-		bytes32 hoard_address,
-		bytes32 hoard_secret,
-		bytes32 event_log_hoard_address,
-		bytes32 event_log_hoard_secret
+		string hoardRefPrivateParameters,
+		string hoardRefEventLog
 	);
 
 	event LogAgreementFormationProcessUpdate(
@@ -57,8 +55,7 @@ contract ActiveAgreementRegistry is EventListener, ProcessStateChangeListener, U
 	event LogAgreementEventLogReference(
 		bytes32 indexed eventId,
 		address agreement_address, 
-		bytes32 event_log_hoard_address,
-		bytes32 event_log_hoard_secret
+		string hoardRefEventLog
 	);
 
 	event LogAgreementCollectionCreation(
@@ -112,25 +109,18 @@ contract ActiveAgreementRegistry is EventListener, ProcessStateChangeListener, U
 	 * @param _archetype archetype
 	 * @param _name name
 	 * @param _creator address
-	 * @param _hoardAddress Address of agreement params in hoard
-	 * @param _hoardSecret Secret for hoard retrieval
+	 * @param _hoardRefPrivateParameters reference of the private parametes of this agreement in Hoard
 	 * @param _isPrivate agreement is private
 	 * @param _parties parties array
 	 * @param _collectionId id of agreement collection (optional)
 	 * @param _governingAgreements array of agreement addresses which govern this agreement (optional)
 	 * @return activeAgreement - the new ActiveAgreement's address, if successfully created, 0x0 otherwise
-	 * Reverts if:
-	 * 	Agreement name or archetype address is empty
-	 * 	Duplicate governing agreements are passed
-	 * 	Agreement address is already registered
-	 * 	Given collectionId does not exist
 	 */
 	function createAgreement(
 		address _archetype,
 		string _name, 
 		address _creator, 
-		bytes32 _hoardAddress, 
-		bytes32 _hoardSecret,
+		string _hoardRefPrivateParameters,
 		bool _isPrivate,
 		address[] _parties, 
 		bytes32 _collectionId, 
@@ -214,17 +204,15 @@ contract ActiveAgreementRegistry is EventListener, ProcessStateChangeListener, U
 	 * @return archetype - the agreement's archetype adress
 	 * @return name - the name of the agreement
 	 * @return creator - the creator of the agreement
-	 * @return hoardAddress - address of the agreement parameters in hoard (only used when agreement is private)
-	 * @return hoardSecret - secret for retrieval of hoard parameters
-	 * @return eventLogHoardAddress - address of the agreement's event log in hoard
-	 * @return eventLogHoardSecret - secret for retrieval of the hoard event log file
+	 * @return hoardRefPrivateParameters - reference to the agreement parameters in Hoard (only used when agreement is private)
+	 * @return hoardRefEventLog - address of the agreement's event log in Hoard
 	 * @return maxNumberOfEvents - the maximum number of events allowed to be stored for this agreement
 	 * @return isPrivate - whether the agreement's parameters are private, i.e. stored off-chain in hoard
 	 * @return legalState - the agreement's Agreement.LegalState as uint8
 	 * @return formationProcessInstance - the address of the process instance representing the formation of this agreement
 	 * @return executionProcessInstance - the address of the process instance representing the execution of this agreement
 	 */
-	function getActiveAgreementData(address _activeAgreement) external view returns (address archetype, string name, address creator, bytes32 hoardAddress, bytes32 hoardSecret, bytes32 eventLogHoardAddress, bytes32 eventLogHoardSecret, uint maxNumberOfEvents, bool isPrivate, uint8 legalState, address formationProcessInstance, address executionProcessInstance);
+	function getActiveAgreementData(address _activeAgreement) external view returns (address archetype, string name, address creator, string hoardRefPrivateParameters, string hoardRefEventLog, uint maxNumberOfEvents, bool isPrivate, uint8 legalState, address formationProcessInstance, address executionProcessInstance);
 
     /**
 	 * @dev Returns the number of agreement parameter entries.
@@ -264,12 +252,11 @@ contract ActiveAgreementRegistry is EventListener, ProcessStateChangeListener, U
 	function getPartyByActiveAgreementData(address _activeAgreement, address _party) external view returns (address signedBy, uint signatureTimestamp);
 
 	/**
-	 * @dev Updates the hoard address and secret for the event log of the specified agreement
-	 * @param _activeAgreement Address of active agreement
-	 * @param _eventLogHoardAddress New hoard address of event log for agreement
-	 * @param _eventLogHoardSecret New hoard secret key of event log for agreement
+	 * @dev Updates the Hoard reference for the event log of the specified agreement
+	 * @param _activeAgreement the address of active agreement
+	 * @param _hoardRefEventLog a hoard reference of the event log of this agreement
 	 */
-	 function setEventLogReference(address _activeAgreement, bytes32 _eventLogHoardAddress, bytes32 _eventLogHoardSecret) external;
+	 function setEventLogReference(address _activeAgreement, string _hoardRefEventLog) external;
 
 	/**
 	 * @dev Creates a new agreement collection

--- a/contracts/src/agreements/Archetype.sol
+++ b/contracts/src/agreements/Archetype.sol
@@ -12,10 +12,10 @@ contract Archetype is Named {
 	/**
 	 * @dev Adds the document specified by the external reference to the archetype under the given name
 	 * @param _name name
-	 * @param _hoardRef the external reference to the document
+	 * @param _fileReference the external reference to the document
 	 * @return error code indicating success or failure
 	 */
-	function addDocument(string _name, string _hoardRef) external returns (uint error);
+	function addDocument(string _name, string _fileReference) external returns (uint error);
 
 	/**
 	 * @dev Adds a parameter to this Archetype
@@ -64,9 +64,9 @@ contract Archetype is Named {
 	 * @dev Gets document reference with given name
 	 * @param _name document name
 	 * @return error - an error code
-	 * @return hoardRef - the reference to the external document
+	 * @return fileReference - the reference to the external document
 	 */
-	function getDocument(string _name) external view returns (uint error, string hoardRef);
+	function getDocument(string _name) external view returns (uint error, string fileReference);
 
 	/**
 	 * @dev Gets number of parameters

--- a/contracts/src/agreements/Archetype.sol
+++ b/contracts/src/agreements/Archetype.sol
@@ -10,22 +10,19 @@ import "commons-utils/DataTypes.sol";
 contract Archetype is Named {
 
 	/**
-	 * @dev Adds the document specified by the given parameters to the archetype
+	 * @dev Adds the document specified by the external reference to the archetype under the given name
 	 * @param _name name
-	 * @param _hoardAddress hoard address
-	 * @param _secretKey secret key
+	 * @param _hoardRef the external reference to the document
 	 * @return error code indicating success or failure
 	 */
-	function addDocument(bytes32 _name, bytes32 _hoardAddress, bytes32 _secretKey) external returns (uint error);
+	function addDocument(string _name, string _hoardRef) external returns (uint error);
 
 	/**
-	 * @dev Adds parameter
+	 * @dev Adds a parameter to this Archetype
 	 * @param _parameterType parameter type (enum)
 	 * @param _parameterName parameter name
-	 * @return 
-	 *	 		 BaseErrors.NO_ERROR() and position of parameter, if successful,
-	 *		   BaseErrors.NULL_PARAM_NOT_ALLOWED() if _parameter is empty,
-	 *		   BaseErrors.RESOURCE_ALREADY_EXISTS() if _parameter already exists
+	 * @return error - code indicating success or failure
+	 * @return position - the position at which the parameter was added, if successful
 	 */
 	function addParameter(DataTypes.ParameterType _parameterType, bytes32 _parameterName) external returns (uint error, uint position);
 
@@ -64,11 +61,12 @@ contract Archetype is Named {
 	function getAuthor() external view returns (address author);
 
 	/**
-	 * @dev Gets document with given name
+	 * @dev Gets document reference with given name
 	 * @param _name document name
-	 * @return externalContent external content
+	 * @return error - an error code
+	 * @return hoardRef - the reference to the external document
 	 */
-	function getDocument(bytes32 _name) external view returns (uint error, bytes32 hoardAddress, bytes32 secretKey);
+	function getDocument(string _name) external view returns (uint error, string hoardRef);
 
 	/**
 	 * @dev Gets number of parameters
@@ -105,7 +103,7 @@ contract Archetype is Named {
 	 * @return error BaseErrors.NO_ERROR() or BaseErrors.INDEX_OUT_OF_BOUNDS() if index is out of bounds
 	 * @return name
 	 */
-	function getDocumentAtIndex(uint _index) external view returns (uint error, bytes32 name);
+	function getDocumentAtIndex(uint _index) external view returns (uint error, string name);
 
 	/**
 	 * @dev Returns the number jurisdictions for this archetype

--- a/contracts/src/agreements/ArchetypeRegistry.sol
+++ b/contracts/src/agreements/ArchetypeRegistry.sol
@@ -241,13 +241,13 @@ contract ArchetypeRegistry is Upgradeable {
 	);
 
 	/**
-	 * @dev Adds Hoard document to the given Archetype
+	 * @dev Adds a file reference to the given Archetype
 	 * @param _archetype archetype
 	 * @param _name name
-	 * @param _hoardRef the external reference to the document
+	 * @param _fileReference the external reference to the document
 	 * @return error BaseErrors.NO_ERROR(), BaseErrors.RESOURCE_NOT_FOUND() _archetype does not exist, or see DefaultArchetype
 	 */
-	function addDocument(address _archetype, string _name, string _hoardRef) external returns (uint error);
+	function addDocument(address _archetype, string _name, string _fileReference) external returns (uint error);
 
 	/**
 	 * @dev Sets price of given archetype
@@ -356,9 +356,9 @@ contract ArchetypeRegistry is Upgradeable {
 		* @dev Returns data about the document given the specified name
 		* @param _archetype archetype
 		* @param _name the document name
-		* @return hoardRef - the document reference
+		* @return fileReference - the document reference
 		*/
-	function getDocumentByArchetypeData(address _archetype, string _name) external view returns (string hoardRef);
+	function getDocumentByArchetypeData(address _archetype, string _name) external view returns (string fileReference);
 
 	/**
 		* @dev Gets parameters size for given Archetype

--- a/contracts/src/agreements/ArchetypeRegistry.sol
+++ b/contracts/src/agreements/ArchetypeRegistry.sol
@@ -11,14 +11,6 @@ import "agreements/Agreements.sol";
  */
 contract ArchetypeRegistry is Upgradeable {
 
-  event UpdateArchetypes(string name, address key);
-  event UpdateArchetypeDocuments(string name, address key, bytes32 key2);
-  event UpdateArchetypeParameters(string name, address key1, bytes32 key2);
-	event UpdateArchetypeJurisdictions(string name, address key1, bytes32 key2);
-	event UpdateArchetypePackages(string name, bytes32 key1);
-	event UpdateArchetypePackageMap(string name, bytes32 key1, address key2);
-	event UpdateGoverningArchetypes(string name, address key1, address key2);
-
 	event LogArchetypeCreation(
 		bytes32 indexed eventId,
 		address archetype_address,
@@ -84,10 +76,9 @@ contract ArchetypeRegistry is Upgradeable {
 
 	event LogArchetypeDocumentUpdate(
 		bytes32 indexed eventId,
-		address archetype_address,
-		bytes32 document_key,
-		bytes32 hoard_address,
-		bytes32 secret_key
+		address archetypeAddress,
+		string documentKey,
+		string documentReference
 	);
 
 	event LogArchetypeJurisdictionUpdate(
@@ -253,13 +244,10 @@ contract ArchetypeRegistry is Upgradeable {
 	 * @dev Adds Hoard document to the given Archetype
 	 * @param _archetype archetype
 	 * @param _name name
-	 * @param _hoardAddress hoard address
-	 * @param _secretKey secret key
+	 * @param _hoardRef the external reference to the document
 	 * @return error BaseErrors.NO_ERROR(), BaseErrors.RESOURCE_NOT_FOUND() _archetype does not exist, or see DefaultArchetype
 	 */
-	// TODO: validate for empty params once Solidity is updated
-	// TODO: determine access (presumably only author should be able to call)
-	function addDocument(address _archetype, bytes32 _name, bytes32 _hoardAddress, bytes32 _secretKey) external returns (uint error);
+	function addDocument(address _archetype, string _name, string _hoardRef) external returns (uint error);
 
 	/**
 	 * @dev Sets price of given archetype
@@ -362,16 +350,15 @@ contract ArchetypeRegistry is Upgradeable {
 		* @param _index index
 		* @return name name
 		*/
-	function getDocumentByArchetypeAtIndex(address _archetype, uint _index) external view returns (bytes32 name);
+	function getDocumentByArchetypeAtIndex(address _archetype, uint _index) external view returns (string name);
 
 	/**
 		* @dev Returns data about the document given the specified name
 		* @param _archetype archetype
-		* @param _name name
-		* @return hoardAddress hoard address
-		* @return secretKey secret key
+		* @param _name the document name
+		* @return hoardRef - the document reference
 		*/
-	function getDocumentByArchetypeData(address _archetype, bytes32 _name) external view returns (bytes32 hoardAddress, bytes32 secretKey);
+	function getDocumentByArchetypeData(address _archetype, string _name) external view returns (string hoardRef);
 
 	/**
 		* @dev Gets parameters size for given Archetype

--- a/contracts/src/agreements/DefaultActiveAgreement.sol
+++ b/contracts/src/agreements/DefaultActiveAgreement.sol
@@ -22,13 +22,11 @@ contract DefaultActiveAgreement is ActiveAgreement, AbstractDataStorage, Abstrac
 	using MappingsLib for Mappings.Bytes32Bytes32Map;
 
 	address archetype;
-	string name;
 	address creator;
+	string name;
+	string hoardRefPrivateParameters;
+	string hoardRefEventLog;
 	bool privateFlag;
-	bytes32 hoardAddress;
-	bytes32 hoardSecret;
-	bytes32 eventLogHoardAddress;
-	bytes32 eventLogHoardSecret;
 	uint32 maxNumberOfEvents;
 	address[] parties;
 	Agreements.LegalState legalState = Agreements.LegalState.FORMULATED; //TODO we currently don't support a negotiation phase in the AN, so the agreement's prose contract is already formulated when the agreement is created.
@@ -41,8 +39,7 @@ contract DefaultActiveAgreement is ActiveAgreement, AbstractDataStorage, Abstrac
 	 * @param _archetype archetype address
 	 * @param _name name
 	 * @param _creator the account that created this agreement
-	 * @param _hoardAddress the address of the prose document in Hoard
-	 * @param _hoardSecret the secret to accessing the prose document in Hoard
+	 * @param _hoardRefPrivateParameters the reference to the private parameters in Hoard (optional)
 	 * @param _isPrivate if agreement is private
 	 * @param _parties the signing parties to the agreement
 	 * @param _governingAgreements array of agreement addresses which govern this agreement (optional)
@@ -51,8 +48,7 @@ contract DefaultActiveAgreement is ActiveAgreement, AbstractDataStorage, Abstrac
 		address _archetype, 
 		string _name, 
 		address _creator, 
-		bytes32 _hoardAddress, 
-		bytes32 _hoardSecret,
+		string _hoardRefPrivateParameters, 
 		bool _isPrivate, 
 		address[] _parties, 
 		address[] _governingAgreements) public 
@@ -60,8 +56,7 @@ contract DefaultActiveAgreement is ActiveAgreement, AbstractDataStorage, Abstrac
 		archetype = _archetype;
 		name = _name;
 		creator = _creator;
-		hoardAddress = _hoardAddress;
-		hoardSecret = _hoardSecret;
+		hoardRefPrivateParameters = _hoardRefPrivateParameters;
 		privateFlag = _isPrivate;
 		parties = _parties;
 		governingAgreements = _governingAgreements;
@@ -127,22 +122,12 @@ contract DefaultActiveAgreement is ActiveAgreement, AbstractDataStorage, Abstrac
 		return archetype;
 	}
 
-
 	/**
-	 * @dev Returns the Hoard Address
-	 * @return the Hoard Address	 
+	 * @dev Returns the reference to the private parameters of this ActiveAgreement
+	 * @return the reference to an external document containing private parameters
 	 */
-	function getHoardAddress() external view returns (bytes32){
-		return hoardAddress;
-	}
-
-
-	/**
-	 * @dev Returns the Hoard Secret
-	 * @return the Hoard Secret
-	 */
-	function getHoardSecret() external view returns (bytes32){
-		return hoardSecret;
+	function getPrivateParametersReference() external view returns (string){
+		return hoardRefPrivateParameters;
 	}
 
 	/**
@@ -153,21 +138,20 @@ contract DefaultActiveAgreement is ActiveAgreement, AbstractDataStorage, Abstrac
 	}
 
 	/**
-	 * @dev Sets the Hoard Address and Hoard Secret for the Event Log
+	 * @dev Updates the Hoard reference for the event log of this agreement
+	 * @param _hoardRefEventLog the reference to the event log in Hoard
 	 */
-	function setEventLogReference(bytes32 _eventLogHoardAddress, bytes32 _eventLogHoardSecret) external {
-		eventLogHoardAddress = _eventLogHoardAddress;
-		eventLogHoardSecret = _eventLogHoardSecret;
+	function setEventLogReference(string _hoardRefEventLog) external {
+		hoardRefEventLog = _hoardRefEventLog;
 		emitEvent(EVENT_ID_EVENT_LOG_UPDATED, this);
 	}
 
 	/**
-	 * @dev Returns the Hoard Address and Hoard Secret for the Event Log
-	 * @return the Hoard Address and Hoard Secret for the Event Log
+	 * @dev Returns the reference for the event log of this ActiveAgreement
+	 * @return the reference to an external document containing the event log
 	 */
-	function getEventLogReference() external view returns (bytes32 retEventLogHoardAddress, bytes32 retEventLogHoardSecret) {
-		retEventLogHoardAddress = eventLogHoardAddress;
-		retEventLogHoardSecret = eventLogHoardSecret;
+	function getEventLogReference() external view returns (string) {
+		return hoardRefEventLog;
 	}
 
 	/**

--- a/contracts/src/agreements/DefaultActiveAgreement.sol
+++ b/contracts/src/agreements/DefaultActiveAgreement.sol
@@ -24,8 +24,8 @@ contract DefaultActiveAgreement is ActiveAgreement, AbstractDataStorage, Abstrac
 	address archetype;
 	address creator;
 	string name;
-	string hoardRefPrivateParameters;
-	string hoardRefEventLog;
+	string privateParametersFileReference;
+	string eventLogFileReference;
 	bool privateFlag;
 	uint32 maxNumberOfEvents;
 	address[] parties;
@@ -39,7 +39,7 @@ contract DefaultActiveAgreement is ActiveAgreement, AbstractDataStorage, Abstrac
 	 * @param _archetype archetype address
 	 * @param _name name
 	 * @param _creator the account that created this agreement
-	 * @param _hoardRefPrivateParameters the reference to the private parameters in Hoard (optional)
+	 * @param _privateParametersFileReference the file reference to the private parameters (optional)
 	 * @param _isPrivate if agreement is private
 	 * @param _parties the signing parties to the agreement
 	 * @param _governingAgreements array of agreement addresses which govern this agreement (optional)
@@ -48,7 +48,7 @@ contract DefaultActiveAgreement is ActiveAgreement, AbstractDataStorage, Abstrac
 		address _archetype, 
 		string _name, 
 		address _creator, 
-		string _hoardRefPrivateParameters, 
+		string _privateParametersFileReference, 
 		bool _isPrivate, 
 		address[] _parties, 
 		address[] _governingAgreements) public 
@@ -56,7 +56,7 @@ contract DefaultActiveAgreement is ActiveAgreement, AbstractDataStorage, Abstrac
 		archetype = _archetype;
 		name = _name;
 		creator = _creator;
-		hoardRefPrivateParameters = _hoardRefPrivateParameters;
+		privateParametersFileReference = _privateParametersFileReference;
 		privateFlag = _isPrivate;
 		parties = _parties;
 		governingAgreements = _governingAgreements;
@@ -127,7 +127,7 @@ contract DefaultActiveAgreement is ActiveAgreement, AbstractDataStorage, Abstrac
 	 * @return the reference to an external document containing private parameters
 	 */
 	function getPrivateParametersReference() external view returns (string){
-		return hoardRefPrivateParameters;
+		return privateParametersFileReference;
 	}
 
 	/**
@@ -138,11 +138,11 @@ contract DefaultActiveAgreement is ActiveAgreement, AbstractDataStorage, Abstrac
 	}
 
 	/**
-	 * @dev Updates the Hoard reference for the event log of this agreement
-	 * @param _hoardRefEventLog the reference to the event log in Hoard
+	 * @dev Updates the file reference for the event log of this agreement
+	 * @param _eventLogFileReference the file reference to the event log
 	 */
-	function setEventLogReference(string _hoardRefEventLog) external {
-		hoardRefEventLog = _hoardRefEventLog;
+	function setEventLogReference(string _eventLogFileReference) external {
+		eventLogFileReference = _eventLogFileReference;
 		emitEvent(EVENT_ID_EVENT_LOG_UPDATED, this);
 	}
 
@@ -151,7 +151,7 @@ contract DefaultActiveAgreement is ActiveAgreement, AbstractDataStorage, Abstrac
 	 * @return the reference to an external document containing the event log
 	 */
 	function getEventLogReference() external view returns (string) {
-		return hoardRefEventLog;
+		return eventLogFileReference;
 	}
 
 	/**

--- a/contracts/src/agreements/DefaultActiveAgreementRegistry.sol
+++ b/contracts/src/agreements/DefaultActiveAgreementRegistry.sol
@@ -61,7 +61,7 @@ contract DefaultActiveAgreementRegistry is Versioned(1,0,0), AbstractEventListen
 	 * @param _archetype archetype
 	 * @param _name name
 	 * @param _creator address
-	 * @param _hoardRefPrivateParameters reference of the private parametes of this agreement in Hoard
+	 * @param _privateParametersFileReference the file reference of the private parametes of this agreement
 	 * @param _isPrivate agreement is private
 	 * @param _parties parties array
 	 * @param _collectionId id of agreement collection (optional)
@@ -77,7 +77,7 @@ contract DefaultActiveAgreementRegistry is Versioned(1,0,0), AbstractEventListen
 		address _archetype,
 		string _name, 
 		address _creator, 
-		string _hoardRefPrivateParameters,
+		string _privateParametersFileReference,
 		bool _isPrivate, 
 		address[] _parties, 
 		bytes32 _collectionId, 
@@ -85,7 +85,7 @@ contract DefaultActiveAgreementRegistry is Versioned(1,0,0), AbstractEventListen
 		external returns (address activeAgreement)
 	{
 		validateAgreementRequirements(_archetype, _name, _governingAgreements);
-		activeAgreement = new DefaultActiveAgreement(_archetype, _name, _creator, _hoardRefPrivateParameters, _isPrivate, _parties, _governingAgreements);
+		activeAgreement = new DefaultActiveAgreement(_archetype, _name, _creator, _privateParametersFileReference, _isPrivate, _parties, _governingAgreements);
 		register(activeAgreement, _name);
 		if (_collectionId != "") addAgreementToCollection(_collectionId, activeAgreement);
 		emitAgreementCreationEvent(activeAgreement);
@@ -499,10 +499,10 @@ contract DefaultActiveAgreementRegistry is Versioned(1,0,0), AbstractEventListen
 	 * @return archetype - the agreement's archetype adress
 	 * @return name - the name of the agreement
 	 * @return creator - the creator of the agreement
-	 * @return hoardRefPrivateParameters - reference to the agreement parameters in Hoard (only used when agreement is private)
-	 * @return hoardRefEventLog - address of the agreement's event log in Hoard
+	 * @return privateParametersFileReference - the file reference to the private agreement parameters (only used when agreement is private)
+	 * @return eventLogFileReference - the file reference to the agreement's event log
 	 * @return maxNumberOfEvents - the maximum number of events allowed to be stored for this agreement
-	 * @return isPrivate - whether the agreement's parameters are private, i.e. stored off-chain in Hoard
+	 * @return isPrivate - whether there are private agreement parameters, i.e. stored off-chain
 	 * @return legalState - the agreement's Agreement.LegalState as uint8
 	 * @return formationProcessInstance - the address of the process instance representing the formation of this agreement
 	 * @return executionProcessInstance - the address of the process instance representing the execution of this agreement
@@ -511,8 +511,8 @@ contract DefaultActiveAgreementRegistry is Versioned(1,0,0), AbstractEventListen
 		address archetype,
 		string name,
 		address creator,
-		string hoardRefPrivateParameters,
-		string hoardRefEventLog,
+		string privateParametersFileReference,
+		string eventLogFileReference,
 		uint maxNumberOfEvents,
 		bool isPrivate,
 		uint8 legalState,
@@ -524,8 +524,8 @@ contract DefaultActiveAgreementRegistry is Versioned(1,0,0), AbstractEventListen
 		if (bytes(name).length != 0) {
 			archetype = ActiveAgreement(_activeAgreement).getArchetype();
 			creator = ActiveAgreement(_activeAgreement).getCreator();
-			hoardRefPrivateParameters = ActiveAgreement(_activeAgreement).getPrivateParametersReference();
-			hoardRefEventLog = ActiveAgreement(_activeAgreement).getEventLogReference();
+			privateParametersFileReference = ActiveAgreement(_activeAgreement).getPrivateParametersReference();
+			eventLogFileReference = ActiveAgreement(_activeAgreement).getEventLogReference();
 			maxNumberOfEvents = ActiveAgreement(_activeAgreement).getMaxNumberOfEvents();			
 			isPrivate = ActiveAgreement(_activeAgreement).isPrivate();
 			legalState = ActiveAgreement(_activeAgreement).getLegalState();
@@ -799,13 +799,13 @@ contract DefaultActiveAgreementRegistry is Versioned(1,0,0), AbstractEventListen
 	}
 
 	/**
-	 * @dev Updates the Hoard reference for the event log of the specified agreement
+	 * @dev Updates the file reference for the event log of the specified agreement
 	 * @param _activeAgreement Address of active agreement
-	 * @param _hoardRefEventLog a hoard reference of the event log of this agreement
+	 * @param _eventLogFileReference the file reference of the event log of this agreement
 	 */
-	 function setEventLogReference(address _activeAgreement, string _hoardRefEventLog) external {
-		ActiveAgreement(_activeAgreement).setEventLogReference(_hoardRefEventLog);
-		emit LogAgreementEventLogReference(EVENT_ID_AGREEMENTS, _activeAgreement, _hoardRefEventLog);
+	 function setEventLogReference(address _activeAgreement, string _eventLogFileReference) external {
+		ActiveAgreement(_activeAgreement).setEventLogReference(_eventLogFileReference);
+		emit LogAgreementEventLogReference(EVENT_ID_AGREEMENTS, _activeAgreement, _eventLogFileReference);
 	 }
 
 	/**

--- a/contracts/src/agreements/DefaultActiveAgreementRegistry.sol
+++ b/contracts/src/agreements/DefaultActiveAgreementRegistry.sol
@@ -61,8 +61,7 @@ contract DefaultActiveAgreementRegistry is Versioned(1,0,0), AbstractEventListen
 	 * @param _archetype archetype
 	 * @param _name name
 	 * @param _creator address
-	 * @param _hoardAddress Address of agreement params in hoard
-	 * @param _hoardSecret Secret for hoard retrieval
+	 * @param _hoardRefPrivateParameters reference of the private parametes of this agreement in Hoard
 	 * @param _isPrivate agreement is private
 	 * @param _parties parties array
 	 * @param _collectionId id of agreement collection (optional)
@@ -78,8 +77,7 @@ contract DefaultActiveAgreementRegistry is Versioned(1,0,0), AbstractEventListen
 		address _archetype,
 		string _name, 
 		address _creator, 
-		bytes32 _hoardAddress, 
-		bytes32 _hoardSecret,
+		string _hoardRefPrivateParameters,
 		bool _isPrivate, 
 		address[] _parties, 
 		bytes32 _collectionId, 
@@ -87,7 +85,7 @@ contract DefaultActiveAgreementRegistry is Versioned(1,0,0), AbstractEventListen
 		external returns (address activeAgreement)
 	{
 		validateAgreementRequirements(_archetype, _name, _governingAgreements);
-		activeAgreement = new DefaultActiveAgreement(_archetype, _name, _creator, _hoardAddress, _hoardSecret, _isPrivate, _parties, _governingAgreements);
+		activeAgreement = new DefaultActiveAgreement(_archetype, _name, _creator, _hoardRefPrivateParameters, _isPrivate, _parties, _governingAgreements);
 		register(activeAgreement, _name);
 		if (_collectionId != "") addAgreementToCollection(_collectionId, activeAgreement);
 		emitAgreementCreationEvent(activeAgreement);
@@ -192,10 +190,8 @@ contract DefaultActiveAgreementRegistry is Versioned(1,0,0), AbstractEventListen
 			uint32(0),
 			address(0x0),
 			address(0x0),
-			ActiveAgreement(_activeAgreement).getHoardAddress(),
-			ActiveAgreement(_activeAgreement).getHoardSecret(),
-			bytes32(""),
-			bytes32("")
+			ActiveAgreement(_activeAgreement).getPrivateParametersReference(),
+			ActiveAgreement(_activeAgreement).getEventLogReference()
 		);
 	}
 
@@ -503,12 +499,10 @@ contract DefaultActiveAgreementRegistry is Versioned(1,0,0), AbstractEventListen
 	 * @return archetype - the agreement's archetype adress
 	 * @return name - the name of the agreement
 	 * @return creator - the creator of the agreement
-	 * @return hoardAddress - address of the agreement parameters in hoard (only used when agreement is private)
-	 * @return hoardSecret - secret for retrieval of hoard parameters
-	 * @return eventLogHoardAddress - address of the agreement's event log in hoard
-	 * @return eventLogHoardSecret - secret for retrieval of the hoard event log file
+	 * @return hoardRefPrivateParameters - reference to the agreement parameters in Hoard (only used when agreement is private)
+	 * @return hoardRefEventLog - address of the agreement's event log in Hoard
 	 * @return maxNumberOfEvents - the maximum number of events allowed to be stored for this agreement
-	 * @return isPrivate - whether the agreement's parameters are private, i.e. stored off-chain in hoard
+	 * @return isPrivate - whether the agreement's parameters are private, i.e. stored off-chain in Hoard
 	 * @return legalState - the agreement's Agreement.LegalState as uint8
 	 * @return formationProcessInstance - the address of the process instance representing the formation of this agreement
 	 * @return executionProcessInstance - the address of the process instance representing the execution of this agreement
@@ -517,10 +511,8 @@ contract DefaultActiveAgreementRegistry is Versioned(1,0,0), AbstractEventListen
 		address archetype,
 		string name,
 		address creator,
-		bytes32 hoardAddress,
-		bytes32 hoardSecret,
-		bytes32 eventLogHoardAddress,
-		bytes32 eventLogHoardSecret,
+		string hoardRefPrivateParameters,
+		string hoardRefEventLog,
 		uint maxNumberOfEvents,
 		bool isPrivate,
 		uint8 legalState,
@@ -532,9 +524,8 @@ contract DefaultActiveAgreementRegistry is Versioned(1,0,0), AbstractEventListen
 		if (bytes(name).length != 0) {
 			archetype = ActiveAgreement(_activeAgreement).getArchetype();
 			creator = ActiveAgreement(_activeAgreement).getCreator();
-			hoardAddress = ActiveAgreement(_activeAgreement).getHoardAddress();
-			hoardSecret = ActiveAgreement(_activeAgreement).getHoardSecret();
-			(eventLogHoardAddress, eventLogHoardSecret) = ActiveAgreement(_activeAgreement).getEventLogReference();
+			hoardRefPrivateParameters = ActiveAgreement(_activeAgreement).getPrivateParametersReference();
+			hoardRefEventLog = ActiveAgreement(_activeAgreement).getEventLogReference();
 			maxNumberOfEvents = ActiveAgreement(_activeAgreement).getMaxNumberOfEvents();			
 			isPrivate = ActiveAgreement(_activeAgreement).isPrivate();
 			legalState = ActiveAgreement(_activeAgreement).getLegalState();
@@ -808,14 +799,13 @@ contract DefaultActiveAgreementRegistry is Versioned(1,0,0), AbstractEventListen
 	}
 
 	/**
-	 * @dev Updates the hoard address and secret for the event log of the specified agreement
+	 * @dev Updates the Hoard reference for the event log of the specified agreement
 	 * @param _activeAgreement Address of active agreement
-	 * @param _eventLogHoardAddress New hoard address of event log for agreement
-	 * @param _eventLogHoardSecret New hoard secret key of event log for agreement
+	 * @param _hoardRefEventLog a hoard reference of the event log of this agreement
 	 */
-	 function setEventLogReference(address _activeAgreement, bytes32 _eventLogHoardAddress, bytes32 _eventLogHoardSecret) external {
-		ActiveAgreement(_activeAgreement).setEventLogReference(_eventLogHoardAddress, _eventLogHoardSecret);
-		emit LogAgreementEventLogReference(EVENT_ID_AGREEMENTS, _activeAgreement, _eventLogHoardAddress, _eventLogHoardSecret);
+	 function setEventLogReference(address _activeAgreement, string _hoardRefEventLog) external {
+		ActiveAgreement(_activeAgreement).setEventLogReference(_hoardRefEventLog);
+		emit LogAgreementEventLogReference(EVENT_ID_AGREEMENTS, _activeAgreement, _hoardRefEventLog);
 	 }
 
 	/**

--- a/contracts/src/agreements/DefaultArchetype.sol
+++ b/contracts/src/agreements/DefaultArchetype.sol
@@ -80,19 +80,19 @@ contract DefaultArchetype is Archetype {
 	 * REVERTS if:
 	 * - the name is empty
 	 * @param _name name
-	 * @param _hoardRef the external reference to the document
+	 * @param _fileReference the external reference to the document
 	 * @return error BaseErrors.NO_ERROR() if successful
 	 * @return BaseErrors.RESOURCE_ALREADY_EXISTS() if _name already exists in documentNames
 	 */
 	// TODO: determine access (presumably only author should be able to add documents)
-	function addDocument(string _name, string _hoardRef) external returns (uint error) {
+	function addDocument(string _name, string _fileReference) external returns (uint error) {
 		ErrorsLib.revertIf(bytes(_name).length == 0,
 			ErrorsLib.NULL_PARAMETER_NOT_ALLOWED(), "DefaultArchetype.addDocument", "The name must not be empty");
 		if (documents[_name].exists)
 			return BaseErrors.RESOURCE_ALREADY_EXISTS();
 
 		documentNames.push(_name);
-		documents[_name].reference = _hoardRef;
+		documents[_name].reference = _fileReference;
 		documents[_name].exists = true;
 		error = BaseErrors.NO_ERROR();
 	}
@@ -218,14 +218,14 @@ contract DefaultArchetype is Archetype {
 	 * @dev Gets document reference with given name
 	 * @param _name document name
 	 * @return error BaseErrors.NO_ERROR() or BaseErrors.RESOURCE_NOT_FOUND() if documentNames does not contain _name
-	 * @return hoardRef - the reference to the external document
+	 * @return fileReference - the reference to the external document
 	 */
-	function getDocument(string _name) external view returns (uint error, string hoardRef) {
+	function getDocument(string _name) external view returns (uint error, string fileReference) {
 		error = BaseErrors.NO_ERROR();
 		if (!documents[_name].exists)
 			error = BaseErrors.RESOURCE_NOT_FOUND();
 		else {
-			hoardRef = documents[_name].reference;
+			fileReference = documents[_name].reference;
 		}
 	}
 

--- a/contracts/src/agreements/DefaultArchetypeRegistry.sol
+++ b/contracts/src/agreements/DefaultArchetypeRegistry.sol
@@ -64,7 +64,6 @@ contract DefaultArchetypeRegistry is Versioned(1,0,0), ArchetypeRegistry, Abstra
 		archetype = new DefaultArchetype(_price, _isPrivate, _active, _name, _author, _description,  _formationProcess, _executionProcess, _governingArchetypes);
 		registerArchetype(archetype, _name);
 		for (uint i = 0; i < _governingArchetypes.length; i++) {
-			emit UpdateGoverningArchetypes(TABLE_GOVERNING_ARCHETYPES, archetype, _governingArchetypes[i]);
 			emit LogGoverningArchetypeUpdate(
 				EVENT_ID_GOVERNING_ARCHETYPES, 
 				archetype, 
@@ -92,7 +91,6 @@ contract DefaultArchetypeRegistry is Versioned(1,0,0), ArchetypeRegistry, Abstra
 			Archetype(_archetype).getFormationProcessDefinition(),
 			Archetype(_archetype).getExecutionProcessDefinition()
 		);
-		emit UpdateArchetypes(TABLE_ARCHETYPES, _archetype);
 	}
 
 	/**
@@ -136,7 +134,6 @@ contract DefaultArchetypeRegistry is Versioned(1,0,0), ArchetypeRegistry, Abstra
 	function addArchetypeToPackage(bytes32 _packageId, address _archetype) public {
 		uint error = ArchetypeRegistryDb(database).addArchetypeToPackage(_packageId, _archetype);
 		ErrorsLib.revertIf(error != BaseErrors.NO_ERROR(), ErrorsLib.RESOURCE_NOT_FOUND(), "DefaultArchetypeRegistry.addArchetypeToPackage", "Package not found");
-		emit UpdateArchetypePackageMap(TABLE_ARCHETYPE_TO_PACKAGE, _packageId, _archetype);
 		emit LogArchetypeToPackageUpdate(
 			EVENT_ID_ARCHETYPE_PACKAGE_MAP,
 			_packageId,
@@ -160,7 +157,6 @@ contract DefaultArchetypeRegistry is Versioned(1,0,0), ArchetypeRegistry, Abstra
 			return BaseErrors.RESOURCE_NOT_FOUND();
 		(error, position) = Archetype(_archetype).addParameter(_parameterType, _parameterName);
 		if (error == BaseErrors.NO_ERROR()) {
-			emit UpdateArchetypeParameters(TABLE_ARCHETYPE_PARAMETERS, _archetype, _parameterName);
 			emit LogArchetypeParameterUpdate(
 				EVENT_ID_ARCHETYPE_PARAMETERS,
 				_archetype,
@@ -206,7 +202,6 @@ contract DefaultArchetypeRegistry is Versioned(1,0,0), ArchetypeRegistry, Abstra
 		bytes32 key;
 		(error, key) = Archetype(_archetype).addJurisdiction(_country, _region);
 		if (error == BaseErrors.NO_ERROR()) {
-			emit UpdateArchetypeJurisdictions(TABLE_ARCHETYPE_JURISDICTIONS, _archetype, key);
 			emit LogArchetypeJurisdictionUpdate(
 				EVENT_ID_ARCHETYPE_JURISDICTIONS,
 				_archetype,
@@ -245,7 +240,6 @@ contract DefaultArchetypeRegistry is Versioned(1,0,0), ArchetypeRegistry, Abstra
 		ErrorsLib.revertIf(_archetype == 0x0, ErrorsLib.NULL_PARAMETER_NOT_ALLOWED(), "DefaultArchetypeRegistry.activate", "Arcehtype address must be supplied");
 		ErrorsLib.revertIf(_author != Archetype(_archetype).getAuthor(), ErrorsLib.UNAUTHORIZED(), "DefaultArchetypeRegistry.activate", "Given author address is not authorized to activate archetype");
 		Archetype(_archetype).activate();
-		emit UpdateArchetypes(TABLE_ARCHETYPES, _archetype);
 		emit LogArchetypeActive(EVENT_ID_ARCHETYPES, _archetype, true);
 	}
 
@@ -257,7 +251,6 @@ contract DefaultArchetypeRegistry is Versioned(1,0,0), ArchetypeRegistry, Abstra
 	function deactivate(address _archetype, address _author) external {
 		ErrorsLib.revertIf(_author != Archetype(_archetype).getAuthor(), ErrorsLib.UNAUTHORIZED(), "DefaultArchetypeRegistry.activate", "Given address is not authorized to deactivate archetype");
 		Archetype(_archetype).deactivate();
-		emit UpdateArchetypes(TABLE_ARCHETYPES, _archetype);
 		emit LogArchetypeActive(EVENT_ID_ARCHETYPES, _archetype, false);
 	}
 
@@ -272,7 +265,6 @@ contract DefaultArchetypeRegistry is Versioned(1,0,0), ArchetypeRegistry, Abstra
 		ErrorsLib.revertIf(_author != Archetype(_archetype).getAuthor(), ErrorsLib.UNAUTHORIZED(), "DefaultArchetypeRegistry.setArchetypeSuccessor", "Given author address is not authorized to set successor");
 		ErrorsLib.revertIf(_successor != 0x0 && !ArchetypeRegistryDb(database).archetypeExists(_successor), ErrorsLib.INVALID_INPUT(), "DefaultArchetypeRegistry.setArchetypeSuccessor", "Successor must be a valid archetype");
 		Archetype(_archetype).setSuccessor(_successor);
-		emit UpdateArchetypes(TABLE_ARCHETYPES, _archetype);
 		emit LogArchetypeSuccessorUpdate(EVENT_ID_ARCHETYPES, _archetype, _successor);
 	}
 
@@ -345,24 +337,19 @@ contract DefaultArchetypeRegistry is Versioned(1,0,0), ArchetypeRegistry, Abstra
 	 * @dev Adds Hoard document to the given Archetype
 	 * @param _archetype archetype
 	 * @param _name name
-	 * @param _hoardAddress hoard address
-	 * @param _secretKey secret key
+	 * @param _hoardRef the external reference to the document
 	 * @return error BaseErrors.NO_ERROR(), BaseErrors.RESOURCE_NOT_FOUND() _archetype does not exist, or see DefaultArchetype
 	 */
-	// TODO: validate for empty params once Solidity is updated
-	// TODO: determine access (presumably only author should be able to call)
-	function addDocument(address _archetype, bytes32 _name, bytes32 _hoardAddress, bytes32 _secretKey) external returns (uint error) {
+	function addDocument(address _archetype, string _name, string _hoardRef) external returns (uint error) {
 		if (!ArchetypeRegistryDb(database).archetypeExists(_archetype))
 			return BaseErrors.RESOURCE_NOT_FOUND();
-		error = Archetype(_archetype).addDocument(_name, _hoardAddress, _secretKey);
+		error = Archetype(_archetype).addDocument(_name, _hoardRef);
 		if (error == BaseErrors.NO_ERROR()) {
-			emit UpdateArchetypeDocuments(TABLE_ARCHETYPE_DOCUMENTS, _archetype, _name);
 			emit LogArchetypeDocumentUpdate(
 				EVENT_ID_ARCHETYPE_DOCUMENTS,
 				_archetype,
 				_name,
-				_hoardAddress,
-				_secretKey
+				_hoardRef
 			);
 		}
 	}
@@ -374,7 +361,6 @@ contract DefaultArchetypeRegistry is Versioned(1,0,0), ArchetypeRegistry, Abstra
 	 */
 	function setArchetypePrice(address _archetype, uint32 _price) external {
 		Archetype(_archetype).setPrice(_price);
-		emit UpdateArchetypes(TABLE_ARCHETYPES, _archetype);
 		emit LogArchetypePriceUpdate(
 			EVENT_ID_ARCHETYPES,
 			_archetype,
@@ -397,7 +383,6 @@ contract DefaultArchetypeRegistry is Versioned(1,0,0), ArchetypeRegistry, Abstra
 		id = keccak256(abi.encodePacked(_name, _author, block.timestamp));
 		error = ArchetypeRegistryDb(database).createPackage(id, _name, _description, _author, _isPrivate, _active);
 		if (error == BaseErrors.NO_ERROR()) {
-			emit UpdateArchetypePackages(TABLE_ARCHETYPE_PACKAGES, id);
 			emit LogArchetypePackageCreation(EVENT_ID_ARCHETYPE_PACKAGES, id, _name, _description, _author, _isPrivate, _active);
 		}
 	}
@@ -413,7 +398,6 @@ contract DefaultArchetypeRegistry is Versioned(1,0,0), ArchetypeRegistry, Abstra
 		( , , packageAuthor, , ) = ArchetypeRegistryDb(database).getPackageData(_id);
 		ErrorsLib.revertIf(_author != packageAuthor, ErrorsLib.UNAUTHORIZED(), "DefaultArchetypeRegistry.activatePackage", "Given address is not authorized to activate archetype package");
 		ArchetypeRegistryDb(database).activatePackage(_id);
-		emit UpdateArchetypePackages(TABLE_ARCHETYPE_PACKAGES, _id);
 		emit LogArchetypePackageActive(EVENT_ID_ARCHETYPE_PACKAGES, _id, true);
 	}
 
@@ -428,7 +412,6 @@ contract DefaultArchetypeRegistry is Versioned(1,0,0), ArchetypeRegistry, Abstra
 		( , , packageAuthor, , ) = ArchetypeRegistryDb(database).getPackageData(_id);
 		ErrorsLib.revertIf(_author != packageAuthor, ErrorsLib.UNAUTHORIZED(), "DefaultArchetypeRegistry.activatePackage", "Given address is not authorized to deactivate archetype package");
 		ArchetypeRegistryDb(database).deactivatePackage(_id);
-		emit UpdateArchetypePackages(TABLE_ARCHETYPE_PACKAGES, _id);
 		emit LogArchetypePackageActive(EVENT_ID_ARCHETYPE_PACKAGES, _id, false);
 	}
 
@@ -524,7 +507,7 @@ contract DefaultArchetypeRegistry is Versioned(1,0,0), ArchetypeRegistry, Abstra
      * @param _index index
      * @return name name
      */
-	function getDocumentByArchetypeAtIndex(address _archetype, uint _index) external view returns (bytes32 name) {
+	function getDocumentByArchetypeAtIndex(address _archetype, uint _index) external view returns (string name) {
 		uint error;
 		(error, name) = Archetype(_archetype).getDocumentAtIndex(_index);
 	}
@@ -532,13 +515,12 @@ contract DefaultArchetypeRegistry is Versioned(1,0,0), ArchetypeRegistry, Abstra
     /**
      * @dev Returns data about the document at the specified address
 	 * @param _archetype archetype
-	 * @param _name name
-	 * @return _hoardAddress hoard address
-	 * @return _secretKey secret key
+	 * @param _name the document name
+	 * @return hoardRef - the document reference
 	 */
-	function getDocumentByArchetypeData(address _archetype, bytes32 _name) external view returns (bytes32 hoardAddress, bytes32 secretKey) {
+	function getDocumentByArchetypeData(address _archetype, string _name) external view returns (string hoardRef) {
 		uint error;
-		(error, hoardAddress, secretKey) = Archetype(_archetype).getDocument(_name);
+		(error, hoardRef) = Archetype(_archetype).getDocument(_name);
 	}
 
     /**

--- a/contracts/src/agreements/DefaultArchetypeRegistry.sol
+++ b/contracts/src/agreements/DefaultArchetypeRegistry.sol
@@ -334,22 +334,22 @@ contract DefaultArchetypeRegistry is Versioned(1,0,0), ArchetypeRegistry, Abstra
 	}
 
 	/**
-	 * @dev Adds Hoard document to the given Archetype
+	 * @dev Adds a file reference to the given Archetype
 	 * @param _archetype archetype
 	 * @param _name name
-	 * @param _hoardRef the external reference to the document
+	 * @param _fileReference the external reference to the document
 	 * @return error BaseErrors.NO_ERROR(), BaseErrors.RESOURCE_NOT_FOUND() _archetype does not exist, or see DefaultArchetype
 	 */
-	function addDocument(address _archetype, string _name, string _hoardRef) external returns (uint error) {
+	function addDocument(address _archetype, string _name, string _fileReference) external returns (uint error) {
 		if (!ArchetypeRegistryDb(database).archetypeExists(_archetype))
 			return BaseErrors.RESOURCE_NOT_FOUND();
-		error = Archetype(_archetype).addDocument(_name, _hoardRef);
+		error = Archetype(_archetype).addDocument(_name, _fileReference);
 		if (error == BaseErrors.NO_ERROR()) {
 			emit LogArchetypeDocumentUpdate(
 				EVENT_ID_ARCHETYPE_DOCUMENTS,
 				_archetype,
 				_name,
-				_hoardRef
+				_fileReference
 			);
 		}
 	}
@@ -516,11 +516,11 @@ contract DefaultArchetypeRegistry is Versioned(1,0,0), ArchetypeRegistry, Abstra
      * @dev Returns data about the document at the specified address
 	 * @param _archetype archetype
 	 * @param _name the document name
-	 * @return hoardRef - the document reference
+	 * @return fileReference - the document reference
 	 */
-	function getDocumentByArchetypeData(address _archetype, string _name) external view returns (string hoardRef) {
+	function getDocumentByArchetypeData(address _archetype, string _name) external view returns (string fileReference) {
 		uint error;
-		(error, hoardRef) = Archetype(_archetype).getDocument(_name);
+		(error, fileReference) = Archetype(_archetype).getDocument(_name);
 	}
 
     /**

--- a/contracts/src/agreements/test/ActiveAgreementRegistryTest.sol
+++ b/contracts/src/agreements/test/ActiveAgreementRegistryTest.sol
@@ -25,10 +25,7 @@ contract ActiveAgreementRegistryTest {
 	DefaultArchetype archetype;
 	address public archetypeAddr;
 	address public falseAddress = 0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa;
-	bytes32 dummyHoardAddress = "hoardAddress";
-	bytes32 dummyHoardSecret = "hoardSecret";
-	bytes32 dummyEventLogHoardAddress = "eventLogHoardAddress";
-	bytes32 dummyEventLogHoardSecret = "eventLogHoardSecret";
+	string dummyHoardRefPrivateParameters = "{TODO json hoard grant}";
 	uint maxNumberOfEvents = 5;
 
 	string agreementName = "active agreement name";
@@ -72,11 +69,11 @@ contract ActiveAgreementRegistryTest {
 
 		if (address(agreementRegistry).call(bytes4(keccak256(abi.encodePacked(
 			"createAgreement(address,bytes32,address,bytes32,bytes32,bool,address[],bytes32,address[])"))), 
-			0x0, agreementName, this, dummyHoardAddress, dummyHoardSecret, false, parties, EMPTY, emptyArray)) {
+			0x0, agreementName, this, dummyHoardRefPrivateParameters, false, parties, EMPTY, emptyArray)) {
 				return "Expected error NULL_PARAM_NOT_ALLOWED for empty archetype address";
 		}
 
-		activeAgreement = agreementRegistry.createAgreement(archetype, agreementName, this, dummyHoardAddress, dummyHoardSecret, false, parties, EMPTY, emptyArray);
+		activeAgreement = agreementRegistry.createAgreement(archetype, agreementName, this, dummyHoardRefPrivateParameters, false, parties, EMPTY, emptyArray);
 		if (activeAgreement == 0x0) return "Agreement creation returned empty address";
 
 		if (agreementRegistry.getActiveAgreementAtIndex(0) != activeAgreement) return "ActiveAgreement at index 0 not as expected";
@@ -87,16 +84,14 @@ contract ActiveAgreementRegistryTest {
 		address retArchetype;
 		string memory retName;
 		address retCreator;
-		bytes32 retHoardAddress;
-		bytes32 retHoardSecret;
+		string memory retHoardRef;
 		bool retIsPrivate;
-		(retArchetype, retName, retCreator, retHoardAddress, retHoardSecret, , , , retIsPrivate, , , ) = agreementRegistry.getActiveAgreementData(activeAgreement);
+		(retArchetype, retName, retCreator, retHoardRef, , , retIsPrivate, , , ) = agreementRegistry.getActiveAgreementData(activeAgreement);
 		
 		if (retArchetype != address(archetype)) return "getActiveAgreementData returned wrong archetype";
 		if (bytes(retName).length != bytes(agreementName).length) return "getActiveAgreementData returned wrong name";
 		if (retCreator != address(this)) return "getActiveAgreementData returned wrong creator";
-		if (retHoardAddress != dummyHoardAddress) return "getActiveAgreementData returned wrong hoard address";
-		if (retHoardSecret != dummyHoardSecret) return "getActiveAgreementData returned wrong hoard secret";
+		if (keccak256(abi.encodePacked(retHoardRef)) != keccak256(abi.encodePacked(dummyHoardRefPrivateParameters))) return "getActiveAgreementData returned wrong hoard reference";
 		if (retIsPrivate != false) return "getActiveAgreementData returned wrong isPrivate";
 
 		// test external party data retrieval
@@ -124,7 +119,7 @@ contract ActiveAgreementRegistryTest {
 		archetypeAddr = archRegistry.createArchetype(10, false, true, "archetype name", falseAddress, "description", falseAddress, falseAddress, EMPTY, emptyArray);
 		if (archetypeAddr == 0x0) return "Archetype creation returned empty address";
 
-		activeAgreement = agreementRegistry.createAgreement(archetypeAddr, agreementName, this, dummyHoardAddress, dummyHoardSecret, false, parties, EMPTY, emptyArray);
+		activeAgreement = agreementRegistry.createAgreement(archetypeAddr, agreementName, this, dummyHoardRefPrivateParameters, false, parties, EMPTY, emptyArray);
 		if (activeAgreement == 0x0) return "Agreement creation returned empty address";
 
 		if (address(agreementRegistry).call(bytes4(keccak256(abi.encodePacked("addAgreementToCollection(bytes32,address)"))), fakeCollectionId, activeAgreement)) {
@@ -175,7 +170,7 @@ contract ActiveAgreementRegistryTest {
 
 		if (agreementRegistry.getNumberOfAgreementCollections() != 3) return "Registry should have 3 collections";
 
-		activeAgreement2 = agreementRegistry.createAgreement(archetypeAddr, agreementName, this, dummyHoardAddress, dummyHoardSecret, false, parties, leaseCollectionId2, emptyArray);
+		activeAgreement2 = agreementRegistry.createAgreement(archetypeAddr, agreementName, this, dummyHoardRefPrivateParameters, false, parties, leaseCollectionId2, emptyArray);
 		if (activeAgreement2 == 0x0) return "Failed to create a second agreement to put into lease collection 2";
 
 		if (agreementRegistry.getNumberOfAgreementsInCollection(leaseCollectionId2) != 2) return "Lease collection 2 should now have 2 agreements";
@@ -190,11 +185,11 @@ contract ActiveAgreementRegistryTest {
 		
 		// trying to create a ndaAgreement with a governing employmentAgreement when the ndaArchetype does not have a governing employmentArchetype should fail
 		ndaArchetype = archRegistry.createArchetype(10, false, true, "ndaArchetype", falseAddress, "ndaArchetype", falseAddress, falseAddress, EMPTY, emptyArray);
-		employmentAgreement = agreementRegistry.createAgreement(employmentArchetype, agreementName, this, dummyHoardAddress, dummyHoardSecret, false, parties, EMPTY, emptyArray);
+		employmentAgreement = agreementRegistry.createAgreement(employmentArchetype, agreementName, this, dummyHoardRefPrivateParameters, false, parties, EMPTY, emptyArray);
 		governingAgreements.push(employmentAgreement);
 		if (address(agreementRegistry).call(bytes4(keccak256(abi.encodePacked(
 			"createAgreement(address,bytes32,address,bytes32,bytes32,bytes32,bytes32,uint,bool,address[],bytes32,address[])"))),
-			ndaArchetype, agreementName, this, dummyHoardAddress, dummyHoardSecret, false, parties, EMPTY, governingAgreements)) {
+			ndaArchetype, agreementName, this, dummyHoardRefPrivateParameters, false, parties, EMPTY, governingAgreements)) {
 				return "Expected failure when creating agreement with governing agreements when its archetype has no governing archetypes";
 		}
 
@@ -204,24 +199,24 @@ contract ActiveAgreementRegistryTest {
 		ndaArchetype = archRegistry.createArchetype(10, false, true, "ndaArchetype", falseAddress, "ndaArchetype", falseAddress, falseAddress, EMPTY, governingArchetypes);
 		if (address(agreementRegistry).call(bytes4(keccak256(abi.encodePacked(
 			"createAgreement(address,bytes32,address,bytes32,bytes32,bytes32,bytes32,uint,bool,address[],bytes32,address[])"))),
-			ndaArchetype, agreementName, this, dummyHoardAddress, dummyHoardSecret, false, parties, EMPTY, governingAgreements)) {
+			ndaArchetype, agreementName, this, dummyHoardRefPrivateParameters, false, parties, EMPTY, governingAgreements)) {
 				return "Expected failure when creating agreement with governing agreements when its archetype has no governing archetypes";
 		}
 
 		// trying to create a ndaAgreement with a unrelated governing agreement when the ndaArchetype has a governing employmentArchetype should fail
 		benefitsArchetype = archRegistry.createArchetype(10, false, true, "benefitsArchetype", falseAddress, "benefitsArchetype", falseAddress, falseAddress, EMPTY, emptyArray);
-		benefitsAgreement = agreementRegistry.createAgreement(benefitsArchetype, agreementName, this, dummyHoardAddress, dummyHoardSecret, false, parties, EMPTY, emptyArray);
+		benefitsAgreement = agreementRegistry.createAgreement(benefitsArchetype, agreementName, this, dummyHoardRefPrivateParameters, false, parties, EMPTY, emptyArray);
 		governingAgreements.push(benefitsAgreement);
 		if (address(agreementRegistry).call(bytes4(keccak256(abi.encodePacked(
 			"createAgreement(address,bytes32,address,bytes32,bytes32,bytes32,bytes32,uint,bool,address[],bytes32,address[])"))),
-			ndaArchetype, agreementName, this, dummyHoardAddress, dummyHoardSecret, false, parties, EMPTY, governingAgreements)) {
+			ndaArchetype, agreementName, this, dummyHoardRefPrivateParameters, false, parties, EMPTY, governingAgreements)) {
 				return "Expected failure when creating an agreement with a governing agreement that does not match its governing archetype";
 		}
 
 		// trying to create a ndaAgreement with a governing employmentAgreement when the ndaArchetype has a governing employmentArchetype should pass
 		governingAgreements.length = 0;
 		governingAgreements.push(employmentAgreement);
-		ndaAgreement = agreementRegistry.createAgreement(ndaArchetype, agreementName, this, dummyHoardAddress, dummyHoardSecret, false, parties, EMPTY, governingAgreements);
+		ndaAgreement = agreementRegistry.createAgreement(ndaArchetype, agreementName, this, dummyHoardRefPrivateParameters, false, parties, EMPTY, governingAgreements);
 		if (ndaAgreement == 0x0) return "Failed to create ndaAgreement with expected governing agreement employmentAgreement";
 		
 		return SUCCESS;

--- a/contracts/src/agreements/test/ActiveAgreementRegistryTest.sol
+++ b/contracts/src/agreements/test/ActiveAgreementRegistryTest.sol
@@ -25,7 +25,7 @@ contract ActiveAgreementRegistryTest {
 	DefaultArchetype archetype;
 	address public archetypeAddr;
 	address public falseAddress = 0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa;
-	string dummyHoardRefPrivateParameters = "{TODO json hoard grant}";
+	string dummyPrivateParametersFileRef = "{json grant}";
 	uint maxNumberOfEvents = 5;
 
 	string agreementName = "active agreement name";
@@ -69,11 +69,11 @@ contract ActiveAgreementRegistryTest {
 
 		if (address(agreementRegistry).call(bytes4(keccak256(abi.encodePacked(
 			"createAgreement(address,bytes32,address,bytes32,bytes32,bool,address[],bytes32,address[])"))), 
-			0x0, agreementName, this, dummyHoardRefPrivateParameters, false, parties, EMPTY, emptyArray)) {
+			0x0, agreementName, this, dummyPrivateParametersFileRef, false, parties, EMPTY, emptyArray)) {
 				return "Expected error NULL_PARAM_NOT_ALLOWED for empty archetype address";
 		}
 
-		activeAgreement = agreementRegistry.createAgreement(archetype, agreementName, this, dummyHoardRefPrivateParameters, false, parties, EMPTY, emptyArray);
+		activeAgreement = agreementRegistry.createAgreement(archetype, agreementName, this, dummyPrivateParametersFileRef, false, parties, EMPTY, emptyArray);
 		if (activeAgreement == 0x0) return "Agreement creation returned empty address";
 
 		if (agreementRegistry.getActiveAgreementAtIndex(0) != activeAgreement) return "ActiveAgreement at index 0 not as expected";
@@ -84,14 +84,14 @@ contract ActiveAgreementRegistryTest {
 		address retArchetype;
 		string memory retName;
 		address retCreator;
-		string memory retHoardRef;
+		string memory returnedFileRef;
 		bool retIsPrivate;
-		(retArchetype, retName, retCreator, retHoardRef, , , retIsPrivate, , , ) = agreementRegistry.getActiveAgreementData(activeAgreement);
+		(retArchetype, retName, retCreator, returnedFileRef, , , retIsPrivate, , , ) = agreementRegistry.getActiveAgreementData(activeAgreement);
 		
 		if (retArchetype != address(archetype)) return "getActiveAgreementData returned wrong archetype";
 		if (bytes(retName).length != bytes(agreementName).length) return "getActiveAgreementData returned wrong name";
 		if (retCreator != address(this)) return "getActiveAgreementData returned wrong creator";
-		if (keccak256(abi.encodePacked(retHoardRef)) != keccak256(abi.encodePacked(dummyHoardRefPrivateParameters))) return "getActiveAgreementData returned wrong hoard reference";
+		if (keccak256(abi.encodePacked(returnedFileRef)) != keccak256(abi.encodePacked(dummyPrivateParametersFileRef))) return "getActiveAgreementData returned wrong private parameters file reference";
 		if (retIsPrivate != false) return "getActiveAgreementData returned wrong isPrivate";
 
 		// test external party data retrieval
@@ -119,7 +119,7 @@ contract ActiveAgreementRegistryTest {
 		archetypeAddr = archRegistry.createArchetype(10, false, true, "archetype name", falseAddress, "description", falseAddress, falseAddress, EMPTY, emptyArray);
 		if (archetypeAddr == 0x0) return "Archetype creation returned empty address";
 
-		activeAgreement = agreementRegistry.createAgreement(archetypeAddr, agreementName, this, dummyHoardRefPrivateParameters, false, parties, EMPTY, emptyArray);
+		activeAgreement = agreementRegistry.createAgreement(archetypeAddr, agreementName, this, dummyPrivateParametersFileRef, false, parties, EMPTY, emptyArray);
 		if (activeAgreement == 0x0) return "Agreement creation returned empty address";
 
 		if (address(agreementRegistry).call(bytes4(keccak256(abi.encodePacked("addAgreementToCollection(bytes32,address)"))), fakeCollectionId, activeAgreement)) {
@@ -170,7 +170,7 @@ contract ActiveAgreementRegistryTest {
 
 		if (agreementRegistry.getNumberOfAgreementCollections() != 3) return "Registry should have 3 collections";
 
-		activeAgreement2 = agreementRegistry.createAgreement(archetypeAddr, agreementName, this, dummyHoardRefPrivateParameters, false, parties, leaseCollectionId2, emptyArray);
+		activeAgreement2 = agreementRegistry.createAgreement(archetypeAddr, agreementName, this, dummyPrivateParametersFileRef, false, parties, leaseCollectionId2, emptyArray);
 		if (activeAgreement2 == 0x0) return "Failed to create a second agreement to put into lease collection 2";
 
 		if (agreementRegistry.getNumberOfAgreementsInCollection(leaseCollectionId2) != 2) return "Lease collection 2 should now have 2 agreements";
@@ -185,11 +185,11 @@ contract ActiveAgreementRegistryTest {
 		
 		// trying to create a ndaAgreement with a governing employmentAgreement when the ndaArchetype does not have a governing employmentArchetype should fail
 		ndaArchetype = archRegistry.createArchetype(10, false, true, "ndaArchetype", falseAddress, "ndaArchetype", falseAddress, falseAddress, EMPTY, emptyArray);
-		employmentAgreement = agreementRegistry.createAgreement(employmentArchetype, agreementName, this, dummyHoardRefPrivateParameters, false, parties, EMPTY, emptyArray);
+		employmentAgreement = agreementRegistry.createAgreement(employmentArchetype, agreementName, this, dummyPrivateParametersFileRef, false, parties, EMPTY, emptyArray);
 		governingAgreements.push(employmentAgreement);
 		if (address(agreementRegistry).call(bytes4(keccak256(abi.encodePacked(
 			"createAgreement(address,bytes32,address,bytes32,bytes32,bytes32,bytes32,uint,bool,address[],bytes32,address[])"))),
-			ndaArchetype, agreementName, this, dummyHoardRefPrivateParameters, false, parties, EMPTY, governingAgreements)) {
+			ndaArchetype, agreementName, this, dummyPrivateParametersFileRef, false, parties, EMPTY, governingAgreements)) {
 				return "Expected failure when creating agreement with governing agreements when its archetype has no governing archetypes";
 		}
 
@@ -199,24 +199,24 @@ contract ActiveAgreementRegistryTest {
 		ndaArchetype = archRegistry.createArchetype(10, false, true, "ndaArchetype", falseAddress, "ndaArchetype", falseAddress, falseAddress, EMPTY, governingArchetypes);
 		if (address(agreementRegistry).call(bytes4(keccak256(abi.encodePacked(
 			"createAgreement(address,bytes32,address,bytes32,bytes32,bytes32,bytes32,uint,bool,address[],bytes32,address[])"))),
-			ndaArchetype, agreementName, this, dummyHoardRefPrivateParameters, false, parties, EMPTY, governingAgreements)) {
+			ndaArchetype, agreementName, this, dummyPrivateParametersFileRef, false, parties, EMPTY, governingAgreements)) {
 				return "Expected failure when creating agreement with governing agreements when its archetype has no governing archetypes";
 		}
 
 		// trying to create a ndaAgreement with a unrelated governing agreement when the ndaArchetype has a governing employmentArchetype should fail
 		benefitsArchetype = archRegistry.createArchetype(10, false, true, "benefitsArchetype", falseAddress, "benefitsArchetype", falseAddress, falseAddress, EMPTY, emptyArray);
-		benefitsAgreement = agreementRegistry.createAgreement(benefitsArchetype, agreementName, this, dummyHoardRefPrivateParameters, false, parties, EMPTY, emptyArray);
+		benefitsAgreement = agreementRegistry.createAgreement(benefitsArchetype, agreementName, this, dummyPrivateParametersFileRef, false, parties, EMPTY, emptyArray);
 		governingAgreements.push(benefitsAgreement);
 		if (address(agreementRegistry).call(bytes4(keccak256(abi.encodePacked(
 			"createAgreement(address,bytes32,address,bytes32,bytes32,bytes32,bytes32,uint,bool,address[],bytes32,address[])"))),
-			ndaArchetype, agreementName, this, dummyHoardRefPrivateParameters, false, parties, EMPTY, governingAgreements)) {
+			ndaArchetype, agreementName, this, dummyPrivateParametersFileRef, false, parties, EMPTY, governingAgreements)) {
 				return "Expected failure when creating an agreement with a governing agreement that does not match its governing archetype";
 		}
 
 		// trying to create a ndaAgreement with a governing employmentAgreement when the ndaArchetype has a governing employmentArchetype should pass
 		governingAgreements.length = 0;
 		governingAgreements.push(employmentAgreement);
-		ndaAgreement = agreementRegistry.createAgreement(ndaArchetype, agreementName, this, dummyHoardRefPrivateParameters, false, parties, EMPTY, governingAgreements);
+		ndaAgreement = agreementRegistry.createAgreement(ndaArchetype, agreementName, this, dummyPrivateParametersFileRef, false, parties, EMPTY, governingAgreements);
 		if (ndaAgreement == 0x0) return "Failed to create ndaAgreement with expected governing agreement employmentAgreement";
 		
 		return SUCCESS;

--- a/contracts/src/agreements/test/ActiveAgreementTest.sol
+++ b/contracts/src/agreements/test/ActiveAgreementTest.sol
@@ -18,7 +18,7 @@ contract ActiveAgreementTest {
 
 	DefaultArchetype archetype;
 	address falseAddress = 0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa;
-	string dummyHoardRefPrivateParameters = "{TODO json hoard grant}";
+	string dummyPrivateParametersFileRef = "{json grant}";
 	uint maxNumberOfEvents = 5;
 	bytes32 DATA_FIELD_AGREEMENT_PARTIES = "AGREEMENT_PARTIES";
 
@@ -47,7 +47,7 @@ contract ActiveAgreementTest {
 		parties.push(address(signer2));
 
 		archetype = new DefaultArchetype(10, false, true, "archetype name", falseAddress, "description", falseAddress, falseAddress, emptyArray);
-		agreement = new DefaultActiveAgreement(archetype, agreementName, this, dummyHoardRefPrivateParameters, false, parties, emptyArray);
+		agreement = new DefaultActiveAgreement(archetype, agreementName, this, dummyPrivateParametersFileRef, false, parties, emptyArray);
 		agreement.setDataValueAsAddressArray(bogusId, bogusArray);
 
 		if (bytes(agreement.getName()).length != bytes(agreementName).length) return "Name not set correctly";
@@ -89,7 +89,7 @@ contract ActiveAgreementTest {
 		parties.push(address(org1));
 
 		archetype = new DefaultArchetype(10, false, true, "archetype name", falseAddress, "description", falseAddress, falseAddress, emptyArray);
-		agreement = new DefaultActiveAgreement(archetype, agreementName, this, dummyHoardRefPrivateParameters, false, parties, emptyArray);
+		agreement = new DefaultActiveAgreement(archetype, agreementName, this, dummyPrivateParametersFileRef, false, parties, emptyArray);
 
 		// test signing
 		address signee;
@@ -142,8 +142,8 @@ contract ActiveAgreementTest {
 		parties.push(address(signer2));
 
 		archetype = new DefaultArchetype(10, false, true, "archetype name", falseAddress, "description", falseAddress, falseAddress, emptyArray);
-		agreement1 = new DefaultActiveAgreement(archetype, "Agreement1", this, dummyHoardRefPrivateParameters, false, parties, emptyArray);
-		agreement2 = new DefaultActiveAgreement(archetype, "Agreement2", this, dummyHoardRefPrivateParameters, false, parties, emptyArray);
+		agreement1 = new DefaultActiveAgreement(archetype, "Agreement1", this, dummyPrivateParametersFileRef, false, parties, emptyArray);
+		agreement2 = new DefaultActiveAgreement(archetype, "Agreement2", this, dummyPrivateParametersFileRef, false, parties, emptyArray);
 
 		// test invalid cancellation and states
 		if (address(agreement1).call(bytes4(keccak256(abi.encodePacked("cancel()")))))

--- a/contracts/src/agreements/test/ActiveAgreementTest.sol
+++ b/contracts/src/agreements/test/ActiveAgreementTest.sol
@@ -18,10 +18,7 @@ contract ActiveAgreementTest {
 
 	DefaultArchetype archetype;
 	address falseAddress = 0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa;
-	bytes32 dummyHoardAddress = "hoardAddress";
-	bytes32 dummyHoardSecret = "hoardSecret";
-	bytes32 dummyEventLogHoardAddress = "eventLogHoardAddress";
-	bytes32 dummyEventLogHoardSecret = "eventLogHoardSecret";
+	string dummyHoardRefPrivateParameters = "{TODO json hoard grant}";
 	uint maxNumberOfEvents = 5;
 	bytes32 DATA_FIELD_AGREEMENT_PARTIES = "AGREEMENT_PARTIES";
 
@@ -50,7 +47,7 @@ contract ActiveAgreementTest {
 		parties.push(address(signer2));
 
 		archetype = new DefaultArchetype(10, false, true, "archetype name", falseAddress, "description", falseAddress, falseAddress, emptyArray);
-		agreement = new DefaultActiveAgreement(archetype, agreementName, this, dummyHoardAddress, dummyHoardSecret, false, parties, emptyArray);
+		agreement = new DefaultActiveAgreement(archetype, agreementName, this, dummyHoardRefPrivateParameters, false, parties, emptyArray);
 		agreement.setDataValueAsAddressArray(bogusId, bogusArray);
 
 		if (bytes(agreement.getName()).length != bytes(agreementName).length) return "Name not set correctly";
@@ -92,7 +89,7 @@ contract ActiveAgreementTest {
 		parties.push(address(org1));
 
 		archetype = new DefaultArchetype(10, false, true, "archetype name", falseAddress, "description", falseAddress, falseAddress, emptyArray);
-		agreement = new DefaultActiveAgreement(archetype, agreementName, this, dummyHoardAddress, dummyHoardSecret, false, parties, emptyArray);
+		agreement = new DefaultActiveAgreement(archetype, agreementName, this, dummyHoardRefPrivateParameters, false, parties, emptyArray);
 
 		// test signing
 		address signee;
@@ -145,8 +142,8 @@ contract ActiveAgreementTest {
 		parties.push(address(signer2));
 
 		archetype = new DefaultArchetype(10, false, true, "archetype name", falseAddress, "description", falseAddress, falseAddress, emptyArray);
-		agreement1 = new DefaultActiveAgreement(archetype, "Agreement1", this, dummyHoardAddress, dummyHoardSecret, false, parties, emptyArray);
-		agreement2 = new DefaultActiveAgreement(archetype, "Agreement2", this, dummyHoardAddress, dummyHoardSecret, false, parties, emptyArray);
+		agreement1 = new DefaultActiveAgreement(archetype, "Agreement1", this, dummyHoardRefPrivateParameters, false, parties, emptyArray);
+		agreement2 = new DefaultActiveAgreement(archetype, "Agreement2", this, dummyHoardRefPrivateParameters, false, parties, emptyArray);
 
 		// test invalid cancellation and states
 		if (address(agreement1).call(bytes4(keccak256(abi.encodePacked("cancel()")))))

--- a/contracts/src/agreements/test/ActiveAgreementWorkflowTest.sol
+++ b/contracts/src/agreements/test/ActiveAgreementWorkflowTest.sol
@@ -99,7 +99,7 @@ contract ActiveAgreementWorkflowTest {
 		address addr;
 
 		// make an agreement with fields of type address and add role qualifiers. Note: archetype is not used, so setting address to 'this'
-		ActiveAgreement agreement = new DefaultActiveAgreement(this, "RoleQualifierAgreement", this, EMPTY, EMPTY, false, parties, governingAgreements);
+		ActiveAgreement agreement = new DefaultActiveAgreement(this, "RoleQualifierAgreement", this, "", false, parties, governingAgreements);
 		agreement.setDataValueAsBytes32("AgreementRoleField43", "SellerRole");
 		// Adding two scopes to the agreement:
 		// 1. Buyer context: a fixed scope for the msg.sender
@@ -195,7 +195,7 @@ contract ActiveAgreementWorkflowTest {
 		//
 		addr = archetypeRegistry.createArchetype(10, false, true, "Combo1Archetype", this, "description", formationPD, address(0), EMPTY, governingArchetypes);
 		if (addr == 0x0) return "Error creating Combo1Archetype, address is empty";
-		agreement = ActiveAgreement(agreementRegistry.createAgreement(addr, "TestAgreement", this, EMPTY, EMPTY, false, parties, EMPTY, governingAgreements));
+		agreement = ActiveAgreement(agreementRegistry.createAgreement(addr, "TestAgreement", this, "", false, parties, EMPTY, governingAgreements));
 		(error, addr) = agreementRegistry.startProcessLifecycle(ActiveAgreement(agreement));
 		if (error != BaseErrors.NO_ERROR()) return "Error starting formation / no execution combo";
 		if (addr == address(0)) return "Starting formation / no execution combo should return a PI address for formation";
@@ -206,7 +206,7 @@ contract ActiveAgreementWorkflowTest {
 		//
 		addr = archetypeRegistry.createArchetype(10, false, true, "Combo2Archetype", this, "description", address(0), executionPD, EMPTY, governingArchetypes);
 		if (addr == 0x0) return "Error creating Combo2Archetype, address is empty";
-		agreement = ActiveAgreement(agreementRegistry.createAgreement(addr, "TestAgreement", this, EMPTY, EMPTY, false, parties, EMPTY, governingAgreements));
+		agreement = ActiveAgreement(agreementRegistry.createAgreement(addr, "TestAgreement", this, "", false, parties, EMPTY, governingAgreements));
 		// First try fail, because agreement is not executed
 		if (address(agreementRegistry).call(abi.encodeWithSignature("startProcessLifecycle(address)", address(agreement)))) return "Starting no formation / execution combo with a non-executed agreement should fail ";
 		agreement.sign();
@@ -220,7 +220,7 @@ contract ActiveAgreementWorkflowTest {
 		//
 		addr = archetypeRegistry.createArchetype(10, false, true, "Combo3Archetype", this, "description", address(0), address(0), EMPTY, governingArchetypes);
 		if (addr == 0x0) return "Error creating Combo3Archetype, address is empty";
-		agreement = ActiveAgreement(agreementRegistry.createAgreement(addr, "TestAgreement", this, EMPTY, EMPTY, false, parties, EMPTY, governingAgreements));
+		agreement = ActiveAgreement(agreementRegistry.createAgreement(addr, "TestAgreement", this, "", false, parties, EMPTY, governingAgreements));
 		(error, addr) = agreementRegistry.startProcessLifecycle(ActiveAgreement(agreement));
 		if (error != 0) return "Expected empty error code starting no formation / no execution combo";
 		if (addr != address(0)) return "Expected no address starting no formation / no execution combo";
@@ -311,7 +311,7 @@ contract ActiveAgreementWorkflowTest {
 		//
 		// AGREEMENT
 		//
-		address agreement = agreementRegistry.createAgreement(addr, "TestAgreement", this, EMPTY, EMPTY, false, parties, EMPTY, governingAgreements);
+		address agreement = agreementRegistry.createAgreement(addr, "TestAgreement", this, "", false, parties, EMPTY, governingAgreements);
 		// Org2 has a department, so we're setting the additional context on the agreement
 		ActiveAgreement(agreement).setAddressScope(address(org2), DATA_FIELD_AGREEMENT_PARTIES, departmentId1, EMPTY, EMPTY, 0x0);
 		//TODO we currently don't support a negotiation phase in the AN, so the agreement's prose contract is already formulated when the agreement is created.
@@ -452,9 +452,9 @@ contract ActiveAgreementWorkflowTest {
 		//
 		address agreement1;
 		address agreement2;
-		agreement1 = agreementRegistry.createAgreement(addr, "TestAgreement1", this, EMPTY, EMPTY, false, parties, EMPTY, governingAgreements);
+		agreement1 = agreementRegistry.createAgreement(addr, "TestAgreement1", this, "", false, parties, EMPTY, governingAgreements);
 		if (agreement1 == 0x0) return "Unexpected error creating agreement1";
-		agreement2 = agreementRegistry.createAgreement(addr, "TestAgreement2", this, EMPTY, EMPTY, false, parties, EMPTY, governingAgreements);
+		agreement2 = agreementRegistry.createAgreement(addr, "TestAgreement2", this, "", false, parties, EMPTY, governingAgreements);
 		if (agreement2 == 0x0) return "Unexpected error creating agreement2";
 
 		//

--- a/contracts/src/agreements/test/ActiveAgreementWorkflowTest.sol
+++ b/contracts/src/agreements/test/ActiveAgreementWorkflowTest.sol
@@ -60,8 +60,8 @@ contract ActiveAgreementWorkflowTest {
 	UserAccount userAccount3;
 	UserAccount nonPartyAccount;
 
-
 	string constant SUCCESS = "success";
+	string constant dummyModelFileReference = "{json grant}";
 	bytes32 EMPTY = "";
 	bytes32 DATA_FIELD_AGREEMENT_PARTIES = "AGREEMENT_PARTIES";
 
@@ -109,7 +109,7 @@ contract ActiveAgreementWorkflowTest {
 
 		// make a model with participants that point to fields on the agreement
 		ProcessModel pm;
-		(error, addr) = processModelRepository.createProcessModel("RoleQualifiers", "Role Qualifiers", [1,0,0], this, false, EMPTY, EMPTY);
+		(error, addr) = processModelRepository.createProcessModel("RoleQualifiers", "Role Qualifiers", [1,0,0], this, false, dummyModelFileReference);
 		if (addr == 0x0) return "Unable to create a ProcessModel";
 		pm = ProcessModel(addr);
 		pm.addParticipant(participantId1, 0x0, "Buyer", agreementRegistry.DATA_ID_AGREEMENT(), 0x0);
@@ -168,7 +168,7 @@ contract ActiveAgreementWorkflowTest {
 		// the parties to the agreement are: one user, one org, and one org with department scope
 		parties.push(address(this));
 
-		(error, addr) = processModelRepository.createProcessModel("FormationExecution", "Formation Execution", [1,0,0], userAccount1, false, EMPTY, EMPTY);
+		(error, addr) = processModelRepository.createProcessModel("FormationExecution", "Formation Execution", [1,0,0], userAccount1, false, dummyModelFileReference);
 		if (addr == 0x0) return "Unable to create a ProcessModel";
 		pm = ProcessModel(addr);
 		// Formation Process
@@ -280,7 +280,7 @@ contract ActiveAgreementWorkflowTest {
 		// BPM
 		//
 		ProcessModel pm;
-		(error, addr) = processModelRepository.createProcessModel("AN-Model", "AN Model", [1,0,0], userAccount1, false, EMPTY, EMPTY);
+		(error, addr) = processModelRepository.createProcessModel("AN-Model", "AN Model", [1,0,0], userAccount1, false, dummyModelFileReference);
 		if (addr == 0x0) return "Unable to create a ProcessModel";
 		pm = ProcessModel(addr);
 		pm.addParticipant(participantId1, 0x0, DATA_FIELD_AGREEMENT_PARTIES, agreementRegistry.DATA_ID_AGREEMENT(), 0x0);
@@ -421,7 +421,7 @@ contract ActiveAgreementWorkflowTest {
 		// BPM
 		//
 		ProcessModel pm;
-		(error, addr) = processModelRepository.createProcessModel("Cancellation-Model", "Cancellation Model", [1,0,0], userAccount1, false, EMPTY, EMPTY);
+		(error, addr) = processModelRepository.createProcessModel("Cancellation-Model", "Cancellation Model", [1,0,0], userAccount1, false, dummyModelFileReference);
 		if (addr == 0x0) return "Unable to create a ProcessModel";
 		pm = ProcessModel(addr);
 		// Formation Process

--- a/contracts/src/agreements/test/ArchetypeRegistryTest.sol
+++ b/contracts/src/agreements/test/ArchetypeRegistryTest.sol
@@ -24,7 +24,7 @@ contract ArchetypeRegistryTest {
 	string name = "archetype name";
 	string description = "this string description is more than thirty-two characters";
 	string documentName = "documentName";
-	string hoardRef = "{json grant}";
+	string fileReference = "{json grant}";
 	bytes32 parameter = "parameter";
 	DataTypes.ParameterType parameterType = DataTypes.ParameterType.BOOLEAN;
 
@@ -101,16 +101,16 @@ contract ArchetypeRegistryTest {
 
 		// Document Attachments
 
-		error = registry.addDocument(falseAddress, documentName, hoardRef);
+		error = registry.addDocument(falseAddress, documentName, fileReference);
 		if (error != BaseErrors.RESOURCE_NOT_FOUND()) return "Adding document to non-existent archetype should have failed with RESOURCE_NOT_FOUND";
-		error = registry.addDocument(archetype, documentName, hoardRef);
+		error = registry.addDocument(archetype, documentName, fileReference);
 		if (error != BaseErrors.NO_ERROR()) return "Adding document to archetype failed unexpectedly";
 		if (registry.getDocumentsByArchetypeSize(archetype) != 1) return "Documents on archetype exptected to be 1";
 		if (keccak256(abi.encodePacked(registry.getDocumentByArchetypeAtIndex(archetype, 0))) != keccak256(abi.encodePacked(documentName))) return "documentName at index 0 not returned correctly";
 
-		string memory retHoardRef;
-		retHoardRef = registry.getDocumentByArchetypeData(archetype, documentName);
-		if (keccak256(abi.encodePacked(retHoardRef)) != keccak256(abi.encodePacked(hoardRef))) return "document reference for documentName does not match";
+		string memory returnedFileRef;
+		returnedFileRef = registry.getDocumentByArchetypeData(archetype, documentName);
+		if (keccak256(abi.encodePacked(returnedFileRef)) != keccak256(abi.encodePacked(fileReference))) return "document reference for documentName does not match";
 
 		// Jurisdictions
 		bytes32 region = keccak256(abi.encodePacked("CA", "QC"));

--- a/contracts/src/agreements/test/ArchetypeRegistryTest.sol
+++ b/contracts/src/agreements/test/ArchetypeRegistryTest.sol
@@ -23,9 +23,8 @@ contract ArchetypeRegistryTest {
 
 	string name = "archetype name";
 	string description = "this string description is more than thirty-two characters";
-	bytes32 documentName = "documentName";
-	bytes32 hoardAddress = "hoardAddress";
-	bytes32 secretKey = "secretKey";
+	string documentName = "documentName";
+	string hoardRef = "{json grant}";
 	bytes32 parameter = "parameter";
 	DataTypes.ParameterType parameterType = DataTypes.ParameterType.BOOLEAN;
 
@@ -102,18 +101,16 @@ contract ArchetypeRegistryTest {
 
 		// Document Attachments
 
-		error = registry.addDocument(falseAddress, documentName, hoardAddress, secretKey);
+		error = registry.addDocument(falseAddress, documentName, hoardRef);
 		if (error != BaseErrors.RESOURCE_NOT_FOUND()) return "Adding document to non-existent archetype should have failed with RESOURCE_NOT_FOUND";
-		error = registry.addDocument(archetype, documentName, hoardAddress, secretKey);
+		error = registry.addDocument(archetype, documentName, hoardRef);
 		if (error != BaseErrors.NO_ERROR()) return "Adding document to archetype failed unexpectedly";
 		if (registry.getDocumentsByArchetypeSize(archetype) != 1) return "Documents on archetype exptected to be 1";
-		if (registry.getDocumentByArchetypeAtIndex(archetype, 0) != documentName) return "documentName at index 0 not returned correctly";
+		if (keccak256(abi.encodePacked(registry.getDocumentByArchetypeAtIndex(archetype, 0))) != keccak256(abi.encodePacked(documentName))) return "documentName at index 0 not returned correctly";
 
-		bytes32 retHoardAddress;
-		bytes32 retSecretKey;
-		(retHoardAddress, retSecretKey) = registry.getDocumentByArchetypeData(archetype, documentName);
-		if (retHoardAddress != hoardAddress) return "hoardAddress does not match";
-		if (retSecretKey != secretKey) return "secretKey does not match";
+		string memory retHoardRef;
+		retHoardRef = registry.getDocumentByArchetypeData(archetype, documentName);
+		if (keccak256(abi.encodePacked(retHoardRef)) != keccak256(abi.encodePacked(hoardRef))) return "document reference for documentName does not match";
 
 		// Jurisdictions
 		bytes32 region = keccak256(abi.encodePacked("CA", "QC"));

--- a/contracts/src/bpm-model/DefaultProcessDefinition.sol
+++ b/contracts/src/bpm-model/DefaultProcessDefinition.sol
@@ -137,7 +137,6 @@ contract DefaultProcessDefinition is ProcessDefinition, Owned {
 		graphElements.rows[_id].activity.subProcessModelId = _subProcessModelId;
 		graphElements.rows[_id].activity.subProcessDefinitionId = _subProcessDefinitionId;
 		graphElements.rows[_id].exists = true;
-		model.fireActivityDefinitionUpdateEvent(_id);
 		emit LogActivityDefinitionCreation(
 			EVENT_ID_ACTIVITY_DEFINITIONS,
 			address(model),
@@ -215,7 +214,6 @@ contract DefaultProcessDefinition is ProcessDefinition, Owned {
 			}
 		}
 
-		model.fireProcessDefinitionUpdateEvent();
 		return BaseErrors.NO_ERROR();
 	}
 
@@ -284,7 +282,6 @@ contract DefaultProcessDefinition is ProcessDefinition, Owned {
 		processInterfaces.rows[key].keyIdx = processInterfaces.keys.push(key);
 		processInterfaces.rows[key].value = BpmModel.ProcessInterface({model: pm, interfaceId: _interfaceId});
 		processInterfaces.rows[key].exists = true;
-		model.fireProcessDefinitionUpdateEvent();
 		emit LogProcessDefinitionInterfaceIdUpdate(
 			EVENT_ID_PROCESS_DEFINITIONS,
 			address(this),

--- a/contracts/src/bpm-model/DefaultProcessModel.sol
+++ b/contracts/src/bpm-model/DefaultProcessModel.sol
@@ -22,7 +22,7 @@ contract DefaultProcessModel is ProcessModel {
 	BpmModel.ParticipantMap participants;
 	mapping(bytes32 => bool) processInterfaces;
 	bytes32[] processInterfaceKeys;
-	string hoardRefModelFile;
+	string modelFileReference;
 	address author;
 	bool privateFlag;
 
@@ -33,14 +33,14 @@ contract DefaultProcessModel is ProcessModel {
 	 * @param _version the model version
 	 * @param _author the model author
 	 * @param _isPrivate indicates if model is visible only to creator
-	 * @param _hoardRefModelFile the reference to the external model file from which this ProcessModel originated
+	 * @param _modelFileReference the reference to the external model file from which this ProcessModel originated
 	 */
-	constructor(bytes32 _id, string _name, uint8[3] _version, address _author, bool _isPrivate, string _hoardRefModelFile)
+	constructor(bytes32 _id, string _name, uint8[3] _version, address _author, bool _isPrivate, string _modelFileReference)
 		Versioned(_version[0], _version[1], _version[2])
 		AbstractNamedElement(_id, _name)
 		public
 	{
-		hoardRefModelFile = _hoardRefModelFile;
+		modelFileReference = _modelFileReference;
 		author = _author;
 		privateFlag = _isPrivate;
 	}
@@ -79,7 +79,7 @@ contract DefaultProcessModel is ProcessModel {
 	 * @return the external file reference
 	 */
 	function getModelFileReference() external view returns (string) {
-		return hoardRefModelFile;
+		return modelFileReference;
 	}
 
 	/**

--- a/contracts/src/bpm-model/DefaultProcessModelRepository.sol
+++ b/contracts/src/bpm-model/DefaultProcessModelRepository.sol
@@ -33,10 +33,10 @@ contract DefaultProcessModelRepository is Versioned(1,1,0), ProcessModelReposito
 	 * @param _version the model version
 	 * @param _author the model author
 	 * @param _isPrivate indicates if the model is private
-	 * @param _hoardRefModelFile the reference to the external model file from which this ProcessModel originated
+	 * @param _modelFileReference the reference to the external model file from which this ProcessModel originated
 	 */
-	function createProcessModel(bytes32 _id, string _name, uint8[3] _version, address _author, bool _isPrivate, string _hoardRefModelFile) external returns (uint error, address modelAddress) {
-		ProcessModel pm = new DefaultProcessModel(_id, _name, _version, _author, _isPrivate, _hoardRefModelFile);
+	function createProcessModel(bytes32 _id, string _name, uint8[3] _version, address _author, bool _isPrivate, string _modelFileReference) external returns (uint error, address modelAddress) {
+		ProcessModel pm = new DefaultProcessModel(_id, _name, _version, _author, _isPrivate, _modelFileReference);
 		error = addModel(pm);
 		if (error != BaseErrors.NO_ERROR()) //TODO this should revert the model creation if it could not be added
 			return (error, 0x0);

--- a/contracts/src/bpm-model/DefaultProcessModelRepository.sol
+++ b/contracts/src/bpm-model/DefaultProcessModelRepository.sol
@@ -2,7 +2,6 @@ pragma solidity ^0.4.23;
 
 import "commons-base/BaseErrors.sol";
 import "commons-utils/ArrayUtilsAPI.sol";
-import "commons-events/AbstractEventListener.sol";
 import "commons-collections/Mappings.sol";
 import "commons-collections/MappingsLib.sol";
 import "commons-management/AbstractDbUpgradeable.sol";
@@ -17,12 +16,11 @@ import "bpm-model/ProcessModelRepositoryDb.sol";
  * @title DefaultProcessModelRepository
  * @dev Default implementation of the ProcessModelRepository interface
  */
-contract DefaultProcessModelRepository is Versioned(1,1,0), AbstractEventListener, ProcessModelRepository, AbstractDbUpgradeable {
+contract DefaultProcessModelRepository is Versioned(1,1,0), ProcessModelRepository, AbstractDbUpgradeable {
 	
-	string constant TABLE_PROCESS_MODELS = "PROCESS_MODELS";
-	string constant TABLE_PROCESS_DEFINITIONS = "PROCESS_DEFINITIONS";
-	string constant TABLE_ACTIVITY_DEFINITIONS = "ACTIVITY_DEFINITIONS";
-
+	/**
+	 * @dev Modifier to only allow calls to this ProcessModelRepository from a registered ProcessModel
+	 */
 	modifier onlyRegisteredModels() {
 		if (!ProcessModelRepositoryDb(database).modelIsRegistered(msg.sender)) return;
 		_;
@@ -35,13 +33,12 @@ contract DefaultProcessModelRepository is Versioned(1,1,0), AbstractEventListene
 	 * @param _version the model version
 	 * @param _author the model author
 	 * @param _isPrivate indicates if the model is private
-	 * @param _hoardAddress the HOARD address of the model file
-	 * @param _hoardSecret the HOARD secret of the model file
+	 * @param _hoardRefModelFile the reference to the external model file from which this ProcessModel originated
 	 */
-	function createProcessModel(bytes32 _id, string _name, uint8[3] _version, address _author, bool _isPrivate, bytes32 _hoardAddress, bytes32 _hoardSecret) external returns (uint error, address modelAddress) {
-		ProcessModel pm = new DefaultProcessModel(_id, _name, _version, _author, _isPrivate, _hoardAddress, _hoardSecret);
+	function createProcessModel(bytes32 _id, string _name, uint8[3] _version, address _author, bool _isPrivate, string _hoardRefModelFile) external returns (uint error, address modelAddress) {
+		ProcessModel pm = new DefaultProcessModel(_id, _name, _version, _author, _isPrivate, _hoardRefModelFile);
 		error = addModel(pm);
-		if (error != BaseErrors.NO_ERROR())
+		if (error != BaseErrors.NO_ERROR()) //TODO this should revert the model creation if it could not be added
 			return (error, 0x0);
 		modelAddress = address(pm);
 	}
@@ -55,25 +52,6 @@ contract DefaultProcessModelRepository is Versioned(1,1,0), AbstractEventListene
 	function addModel(ProcessModel _model) public returns (uint error) {
 		error = ProcessModelRepositoryDb(database).addModel(_model.getId(), _model.getVersion(), _model);
 		if ( error != BaseErrors.NO_ERROR()) return;
-		// if there is no active model for this ID namespace, yet, then this one becomes the active one by default
-		if (!ProcessModelRepositoryDb(database).modelIsActive(_model.getId())) {
-			ProcessModelRepositoryDb(database).registerActiveModel(_model.getId(), _model);
-		}
-		// TODO - Investigate why the emitEvent from DefaultProcessModel swallows the transmission 
-		// of new Process Model address. Bug: https://plan.monax.io/issue/AN-299
-		// Until it's sorted out we shall not use emitEvent as a way to trigger the ProcessModelRepo to push a sqlsol update.
-		// Instead the ProcessModelRepo will directly issue the push after a new model is created
-		_model.addEventListener("UPDATE_PROCESS_MODELS", this);
-		_model.addEventListener("UPDATE_PROCESS_DEFINITION", this);
-		_model.addEventListener("UPDATE_ACTIVITY_DEFINITION", this);
-		emit UpdateProcessModel(TABLE_PROCESS_MODELS, _model);
-		emitModelCreationEvent(_model);
-	}
-
-	function emitModelCreationEvent(ProcessModel _model) internal {
-		bytes32 hoardAddress;
-		bytes32 hoardSecret;
-		(hoardAddress, hoardSecret) = _model.getDiagram();
 		emit LogProcessModelCreation(
 			EVENT_ID_PROCESS_MODELS,
 			address(_model),
@@ -85,28 +63,36 @@ contract DefaultProcessModelRepository is Versioned(1,1,0), AbstractEventListene
 			_model.getAuthor(),
 			_model.isPrivate(),
 			ProcessModelRepositoryDb(database).getActiveModel(_model.getId()) == address(_model),
-			hoardAddress,
-			hoardSecret
+			_model.getModelFileReference()
 		);
+		// if there is no active model for this ID namespace, yet, then this one becomes the active one by default
+		if (!ProcessModelRepositoryDb(database).modelIsActive(_model.getId())) {
+			ProcessModelRepositoryDb(database).registerActiveModel(_model.getId(), _model);
+		}
 	}
-	
+
 	/**
 	 * @dev Activates the given ProcessModel and deactivates any previously activated model version of the same ID
-	 * @param _model the ProcessModel to activate
-	 * @return BaseErrors.RESOURCE_NOT_FOUND() if the model ID and version is not registered in the repository
-	 * @return BaseErrors.INVALID_STATE() if the model lookup produces an empty address
-	 * @return BaseErrors.INVALID_STATE_CHANGE() if the model registered model with the same ID and version has a different address than the specified one
+	 * @param _model the ProcessModel to activate.
+	 * REVERTS if:
+	 * - the given ProcessModel ID and version are not registered in this ProcessModelRepository
+	 * - there is a registered model with the same ID and version, but the address differs from the given ProcessModel
+	 * - 
 	 */
 	function activateModel(ProcessModel _model) external returns (uint error) {
+		// check if there is an address registered for the model ID and version
 		address addr = ProcessModelRepositoryDb(database).getModel(_model.getId(), _model.getVersion());
-		if (addr == 0x0) return BaseErrors.INVALID_STATE();
-		if (addr != address(_model)) return BaseErrors.INVALID_STATE_CHANGE();
-		addr = ProcessModelRepositoryDb(database).getActiveModel(_model.getId()); // store previously activated model, if any
+		ErrorsLib.revertIf(addr == 0x0,
+			ErrorsLib.RESOURCE_NOT_FOUND(), "DefaultProcessModelRepository.activateModel", "No registered model found that matches the model ID and version");
+		ErrorsLib.revertIf(addr != address(_model),
+			ErrorsLib.INVALID_INPUT(), "DefaultProcessModelRepository.activateModel", "Another ProcessModel address is already registered with the same model ID and version");
+		// re-use the addr field to lookup a previously activated model with the same ID
+		addr = ProcessModelRepositoryDb(database).getActiveModel(_model.getId());
 		ProcessModelRepositoryDb(database).registerActiveModel(_model.getId(), _model);
-		emit UpdateProcessModel(TABLE_PROCESS_MODELS, _model);
+		emit LogProcessModelActivation(EVENT_ID_PROCESS_MODELS, address(_model), true);
 		if (addr != 0x0 && addr != address(_model)) {
 			// previously activated model detected that should be updated
-			emit UpdateProcessModel(TABLE_PROCESS_MODELS, addr);
+			emit LogProcessModelActivation(EVENT_ID_PROCESS_MODELS, address(addr), false);
 		}
 		return BaseErrors.NO_ERROR();
 	}
@@ -159,10 +145,9 @@ contract DefaultProcessModelRepository is Versioned(1,1,0), AbstractEventListene
 	 * @return author - the model's author
 	 * @return isPrivate - indicates if model is private
 	 * @return active - whether the model is active
-	 * @return diagramAddress - the HOARD address of the model diagram file
-	 * @return diagramSecret - the HOARD secret of the model diagram file
+	 * @return modelFileReference - the external reference of the model file
 	 */
-	function getModelData(address _model) external view returns (bytes32 id, string name, uint versionMajor, uint versionMinor, uint versionPatch, address author, bool isPrivate, bool active, bytes32 diagramAddress, bytes32 diagramSecret) {
+	function getModelData(address _model) external view returns (bytes32 id, string name, uint versionMajor, uint versionMinor, uint versionPatch, address author, bool isPrivate, bool active, string modelFileReference) {
 		ProcessModel m = DefaultProcessModel(_model);
 		id = m.getId();
 		name = m.getName();
@@ -172,7 +157,7 @@ contract DefaultProcessModelRepository is Versioned(1,1,0), AbstractEventListene
 		author = m.getAuthor();
 		isPrivate = m.isPrivate();
 		active = ProcessModelRepositoryDb(database).getActiveModel(m.getId()) == _model;
-		(diagramAddress, diagramSecret) = m.getDiagram();
+		modelFileReference = m.getModelFileReference();
 	}
 
 	/**
@@ -258,34 +243,6 @@ contract DefaultProcessModelRepository is Versioned(1,1,0), AbstractEventListene
 	 */
 	function getActivityData(address, address _processDefinition, bytes32 _id) external view returns (uint8 activityType, uint8 taskType, uint8 taskBehavior, bytes32 assignee, bool multiInstance, bytes32 application, bytes32 subProcessModelId, bytes32 subProcessDefinitionId) {
 		return ProcessDefinition(_processDefinition).getActivityData(_id);
-	}
-
-	/**
-	 * @dev Overwrites AbstractEventListener.eventFired to receive UPDATE_PROCESS_MODEL 
-	 * and UPDATE_PROCESS_DEFINITION events from registered models.
-	 * @param _event the event name
-	 * @param _source the event source (process model)
-	 */
-	function eventFired(bytes32 _event, address _source) onlyRegisteredModels external {
-		if (_event == "UPDATE_PROCESS_MODEL") {
-			emit UpdateProcessModel(TABLE_PROCESS_MODELS, msg.sender);
-		}
-		else if (_event == "UPDATE_PROCESS_DEFINITION") {
-			emit UpdateProcessDefinition(TABLE_PROCESS_DEFINITIONS, msg.sender, _source);
-		}
-	}
-
-	/**
-	 * @dev Overwrites AbstractEventListener.eventFired to receive UPDATE_ACTIVITY_DEFINITION 
-	 * events from registered models.
-	 * @param _event the event name
-	 * @param _source the event source (process model)
-	 * @param _activityId the activityId
-	 */
-	function eventFired(bytes32 _event, address _source, bytes32 _activityId) onlyRegisteredModels external {
-		if (_event == "UPDATE_ACTIVITY_DEFINITION") {
-			emit UpdateActivityDefinition(TABLE_ACTIVITY_DEFINITIONS, msg.sender, _source, _activityId);
-		}
 	}
 
 }

--- a/contracts/src/bpm-model/ProcessModel.sol
+++ b/contracts/src/bpm-model/ProcessModel.sol
@@ -1,7 +1,6 @@
 pragma solidity ^0.4.23;
 
 import "commons-base/AbstractNamedElement.sol";
-import "commons-events/EventEmitter.sol";
 import "commons-base/Versioned.sol";
 
 import "bpm-model/BpmModel.sol";
@@ -10,7 +9,7 @@ import "bpm-model/BpmModel.sol";
  * @title ProcessModel Interface
  * @dev Versionized container providing a namespace for a set of business process definitions and their artifacts. 
  */
-contract ProcessModel is EventEmitter, Versioned, AbstractNamedElement {
+contract ProcessModel is Versioned, AbstractNamedElement {
 
 	event LogProcessDefinitionCreation(
 		bytes32 indexed eventId,
@@ -48,21 +47,20 @@ contract ProcessModel is EventEmitter, Versioned, AbstractNamedElement {
 	function getProcessDefinition(bytes32 _id) external view returns (address);
 
 	/**
-	 * @dev Returns the HOARD file information of the model's diagram
-	 * @return location - the HOARD address
-	 * @return secret - the HOARD secret
+	 * @dev Returns the file reference for the model file
+	 * @return the external file reference
 	 */
-	function getDiagram() external view returns (bytes32 location,  bytes32 secret);
+	function getModelFileReference() external view returns (string);
 
 	/**
 	 * @dev Returns model author address
-	 * @return address - model author
+	 * @return the model author
 	 */
 	function getAuthor() external view returns (address);
 
 	/**
 	 * @dev Returns whether the model is private
-	 * @return bool - if model is private
+	 * @return true if the model is private, false otherwise
 	 */
 	function isPrivate() external view returns (bool);
 
@@ -179,13 +177,4 @@ contract ProcessModel is EventEmitter, Versioned, AbstractNamedElement {
 	 */
 	function getDataDefinitionDetailsAtIndex(uint _index) external view returns (bytes32 key, uint parameterType);
 
-	/**
-	 * @dev To be called by a registered process definition to signal an update.
-	 */
-	function fireProcessDefinitionUpdateEvent() external;
-
-	/**
-	 * @dev To be called by a registered process definition to signal an update.
-	 */
-	function fireActivityDefinitionUpdateEvent(bytes32 _activityId) external;
 }

--- a/contracts/src/bpm-model/ProcessModelRepository.sol
+++ b/contracts/src/bpm-model/ProcessModelRepository.sol
@@ -40,9 +40,9 @@ contract ProcessModelRepository is Upgradeable {
 	 * @param _version the model version
 	 * @param _author the model author
 	 * @param _isPrivate indicates if the model is private
-	 * @param _hoardRefModelFile the reference to the external model file from which this ProcessModel originated
+	 * @param _modelFileReference the reference to the external model file from which this ProcessModel originated
 	 */
-	function createProcessModel(bytes32 _id, string _name, uint8[3] _version, address _author, bool _isPrivate, string _hoardRefModelFile) external returns (uint error, address modelAddress);
+	function createProcessModel(bytes32 _id, string _name, uint8[3] _version, address _author, bool _isPrivate, string _modelFileReference) external returns (uint error, address modelAddress);
 
 	/**
 	 * @dev Adds the given ProcessModel to this repository.

--- a/contracts/src/bpm-model/ProcessModelRepository.sol
+++ b/contracts/src/bpm-model/ProcessModelRepository.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.4.23;
 
-import "commons-events/EventListener.sol";
 import "commons-management/Upgradeable.sol";
 
 import "bpm-model/ProcessModel.sol";
@@ -10,12 +9,8 @@ import "bpm-model/BpmModel.sol";
  * @title ProcessModelRepository Interface
  * @dev Manages registered ProcessModel instances with their past and active versions.
  */
-contract ProcessModelRepository is EventListener, Upgradeable {
+contract ProcessModelRepository is Upgradeable {
 	
-	event UpdateProcessModel(string table, address model);
-	event UpdateProcessDefinition(string table, address model, address processDefinition);
-	event UpdateActivityDefinition(string table, address model, address processDefinition, bytes32 activityId);
-
 	event LogProcessModelCreation(
 		bytes32 indexed eventId,
 		address model_address,
@@ -27,8 +22,13 @@ contract ProcessModelRepository is EventListener, Upgradeable {
 		address author,
 		bool is_private,
 		bool active,
-		bytes32 diagram_address,
-		bytes32 diagram_secret
+		string modelFileReference
+	);
+
+	event LogProcessModelActivation(
+		bytes32 indexed eventId,
+		address model_address,
+		bool active
 	);
 
 	bytes32 public constant EVENT_ID_PROCESS_MODELS = "AN://process-models";
@@ -40,10 +40,9 @@ contract ProcessModelRepository is EventListener, Upgradeable {
 	 * @param _version the model version
 	 * @param _author the model author
 	 * @param _isPrivate indicates if the model is private
-	 * @param _hoardAddress the HOARD address of the model file
-	 * @param _hoardSecret the HOARD secret of the model file
+	 * @param _hoardRefModelFile the reference to the external model file from which this ProcessModel originated
 	 */
-	function createProcessModel(bytes32 _id, string _name, uint8[3] _version, address _author, bool _isPrivate, bytes32 _hoardAddress, bytes32 _hoardSecret) external returns (uint error, address modelAddress);
+	function createProcessModel(bytes32 _id, string _name, uint8[3] _version, address _author, bool _isPrivate, string _hoardRefModelFile) external returns (uint error, address modelAddress);
 
 	/**
 	 * @dev Adds the given ProcessModel to this repository.
@@ -98,10 +97,9 @@ contract ProcessModelRepository is EventListener, Upgradeable {
 	 * @return author - the model's author
 	 * @return isPrivate - indicates if model is private
 	 * @return active - whether the model is active
-	 * @return diagramAddress - the HOARD address of the model diagram file
-	 * @return diagramSecret - the HOARD secret of the model diagram file
+	 * @return modelFileReference - the external reference of the model file
 	 */
-	function getModelData(address _model) external view returns (bytes32 id, string name, uint versionMajor, uint versionMinor, uint versionPatch, address author, bool isPrivate, bool active, bytes32 diagramAddress, bytes32 diagramSecret);
+	function getModelData(address _model) external view returns (bytes32 id, string name, uint versionMajor, uint versionMinor, uint versionPatch, address author, bool isPrivate, bool active, string modelFileReference);
 
 	/**
 	 * @dev Returns the process definition address when the model ID and process definition ID are provided

--- a/contracts/src/bpm-model/test/ProcessDefinitionTest.sol
+++ b/contracts/src/bpm-model/test/ProcessDefinitionTest.sol
@@ -30,7 +30,7 @@ contract ProcessDefinitionTest {
 	bytes32 pId;
 	bytes32 pInterface;
 	bytes32 modelId;
-
+	string dummyModelFileReference = "{json grant}";
 	bytes32 EMPTY = "";
 
 	/**
@@ -47,7 +47,7 @@ contract ProcessDefinitionTest {
 		uint error;
 		address newAddress;
 
-		ProcessModel pm = new DefaultProcessModel("testModel", "Test Model", [1,0,0], author, false, EMPTY, EMPTY);
+		ProcessModel pm = new DefaultProcessModel("testModel", "Test Model", [1,0,0], author, false, dummyModelFileReference);
 		(error, newAddress) = pm.createProcessDefinition("p1");
 		ProcessDefinition pd = ProcessDefinition(newAddress);
 		
@@ -188,7 +188,7 @@ contract ProcessDefinitionTest {
 		uint error;
 		address addr;
 
-		ProcessModel pm = new DefaultProcessModel("conditionsModel", "Conditions Model", [1,0,0], author, false, EMPTY, EMPTY);
+		ProcessModel pm = new DefaultProcessModel("conditionsModel", "Conditions Model", [1,0,0], author, false, dummyModelFileReference);
 		(error, addr) = pm.createProcessDefinition("p1");
 		ProcessDefinition pd = ProcessDefinition(addr);
 

--- a/contracts/src/bpm-model/test/ProcessModelRepositoryTest.sol
+++ b/contracts/src/bpm-model/test/ProcessModelRepositoryTest.sol
@@ -15,16 +15,16 @@ contract ProcessModelRepositoryTest {
 
 	address author = 0x9d7fDE63776AaB9E234d656E654ED9876574C54C;
 	uint error;
-	bytes32 EMPTY = "";
+	string dummyModelFileReference = "{json grant}";
 	
 	function testRepository() external returns (string) {
 
 		SystemOwned(db).transferSystemOwnership(repo);
 		AbstractDbUpgradeable(repo).acceptDatabase(db);
 		
-		ProcessModel pm1 = new DefaultProcessModel("testModel", "Test Model", [1,0,0], author, false, EMPTY, EMPTY);
-		ProcessModel pm2 = new DefaultProcessModel("testModel", "Test Model", [2,0,0], author, false, EMPTY, EMPTY);
-		ProcessModel pm3 = new DefaultProcessModel("testModel", "Test Model", [3,0,0], author, false, EMPTY, EMPTY);
+		ProcessModel pm1 = new DefaultProcessModel("testModel", "Test Model", [1,0,0], author, false, dummyModelFileReference);
+		ProcessModel pm2 = new DefaultProcessModel("testModel", "Test Model", [2,0,0], author, false, dummyModelFileReference);
+		ProcessModel pm3 = new DefaultProcessModel("testModel", "Test Model", [3,0,0], author, false, dummyModelFileReference);
 		
 		error = repo.addModel(pm1);
 		if (error != BaseErrors.NO_ERROR()) return "Adding model 1 failed.";

--- a/contracts/src/bpm-model/test/ProcessModelTest.sol
+++ b/contracts/src/bpm-model/test/ProcessModelTest.sol
@@ -15,6 +15,7 @@ contract ProcessModelTest {
 	address participant1Address = 0x776FDe59876aAB7D654D656e654Ed9876574c54c;
 	address author = 0x9d7fDE63776AaB9E234d656E654ED9876574C54C;
 	string modelName = "Test Model";
+	string dummyModelFileReference = "{json grant string}";
 
 	bytes32 EMPTY = "";
 
@@ -23,17 +24,14 @@ contract ProcessModelTest {
 		uint error;
 		address newAddress;
 
-		ProcessModel pm = new DefaultProcessModel("testModel", "Test Model", [1,2,3], author, false, "hoardAddress", "hoardSecret");
+		ProcessModel pm = new DefaultProcessModel("testModel", "Test Model", [1,2,3], author, false, dummyModelFileReference);
 		if (pm.getId() != "testModel") return "ProcessModel ID not set correctly";
 		if (bytes(pm.getName()).length != bytes(modelName).length) return "ProcessModel Name not set correctly";
 		if (pm.getAuthor() != author) return "ProcessModel Author not set correctly";
 		if (pm.isPrivate() != false) return "ProcessModel expected to be public";
 		if (pm.major() != 1 || pm.minor() != 2 || pm.patch() != 3) return "ProcessModel Version not set correctly";
-		bytes32 location;
-		bytes32 secret;
-		(location, secret) = pm.getDiagram();
-		if (location != "hoardAddress") return "wrong hoard location retrieved";
-		if (secret != "hoardSecret") return "wrong hoard secret retrieved";
+		string memory modelFileRef = pm.getModelFileReference();
+		if (keccak256(abi.encodePacked(modelFileRef)) != keccak256(abi.encodePacked(dummyModelFileReference))) return "model file reference should match";
 
 		// data definitions
 		if (pm.getNumberOfDataDefinitions() != 0) return "There should not be any data definitions in the model after creation";

--- a/contracts/src/bpm-runtime/test/BpmServiceTest.sol
+++ b/contracts/src/bpm-runtime/test/BpmServiceTest.sol
@@ -76,6 +76,7 @@ contract BpmServiceTest {
 	address[] parties;
 
 	string constant SUCCESS = "success";
+	string constant dummyModelFileReference = "{json grant}";
 	bytes32 EMPTY = "";
 
 	ProcessModelRepository repository;
@@ -587,7 +588,7 @@ contract BpmServiceTest {
 
 		bytes32 bytes32Value;
 
-		(error, addr) = repository.createProcessModel("testModel2", "Test Model", [1,0,0], modelAuthor, false, EMPTY, EMPTY);
+		(error, addr) = repository.createProcessModel("testModel2", "Test Model", [1,0,0], modelAuthor, false, dummyModelFileReference);
 		if (addr == 0x0) return "Unable to create a ProcessModel";
 		ProcessModel pm = ProcessModel(addr);
 
@@ -669,7 +670,7 @@ contract BpmServiceTest {
 	 */
 	function testInternalProcessExecution() external returns (string) {
 
-		(error, addr) = repository.createProcessModel("testModel3", "Test Model 3", [1,0,0], modelAuthor, false, EMPTY, EMPTY);
+		(error, addr) = repository.createProcessModel("testModel3", "Test Model 3", [1,0,0], modelAuthor, false, dummyModelFileReference);
 		if (addr == 0x0) return "Unable to create a ProcessModel";
 		ProcessModel pm = ProcessModel(addr);
 
@@ -735,7 +736,7 @@ contract BpmServiceTest {
 		bytes32 activityId;
 		uint8 state;
 
-		(error, addr) = repository.createProcessModel("routingModel", "Routing Model", [1,0,0], modelAuthor, false, EMPTY, EMPTY);
+		(error, addr) = repository.createProcessModel("routingModel", "Routing Model", [1,0,0], modelAuthor, false, dummyModelFileReference);
 		if (addr == 0x0) return "Unable to create a ProcessModel";
 		ProcessModel pm = ProcessModel(addr);
 
@@ -826,7 +827,7 @@ contract BpmServiceTest {
 		bytes32 activityId;
 		uint8 state;
 
-		(error, addr) = repository.createProcessModel("loopingModel", "Looping Model", [1,0,0], modelAuthor, false, EMPTY, EMPTY);
+		(error, addr) = repository.createProcessModel("loopingModel", "Looping Model", [1,0,0], modelAuthor, false, dummyModelFileReference);
 		if (addr == 0x0) return "Unable to create a ProcessModel";
 		ProcessModel pm = ProcessModel(addr);
 
@@ -948,7 +949,7 @@ contract BpmServiceTest {
 		// re-usable variables for return values
 		bytes32 activityId;
 
-		(error, addr) = repository.createProcessModel("twoGatewayModel", "2 Gateway Model", [1,0,0], modelAuthor, false, EMPTY, EMPTY);
+		(error, addr) = repository.createProcessModel("twoGatewayModel", "2 Gateway Model", [1,0,0], modelAuthor, false, dummyModelFileReference);
 		if (addr == 0x0) return "Unable to create a ProcessModel";
 		ProcessModel pm = ProcessModel(addr);
 
@@ -1077,7 +1078,7 @@ contract BpmServiceTest {
 		EventApplication eventApp = new EventApplication(service);
 		FailureServiceApplication serviceApp = new FailureServiceApplication();
 
-		(error, addr) = repository.createProcessModel("serviceApplicationsModel", "Service Applications", [1,0,0], modelAuthor, false, EMPTY, EMPTY);
+		(error, addr) = repository.createProcessModel("serviceApplicationsModel", "Service Applications", [1,0,0], modelAuthor, false, dummyModelFileReference);
 		if (addr == 0x0) return "Unable to create a ProcessModel";
 		ProcessModel pm = ProcessModel(addr);
 
@@ -1177,7 +1178,7 @@ contract BpmServiceTest {
 		bytes32 dataStorageId = "agreement";
 		bytes32 dataPathOnProcess = "customAssignee";
 	
-		(error, addr) = repository.createProcessModel("conditionalPerformerModel", "Test Model CP", [1,0,0], modelAuthor, false, EMPTY, EMPTY);
+		(error, addr) = repository.createProcessModel("conditionalPerformerModel", "Test Model CP", [1,0,0], modelAuthor, false, dummyModelFileReference);
 		if (addr == 0x0) return "Unable to create a ProcessModel";
 		ProcessModel pm = ProcessModel(addr);
 
@@ -1247,7 +1248,7 @@ contract BpmServiceTest {
 		error = applicationRegistry.addApplication("Webform1", BpmModel.ApplicationType.WEB, 0x0, bytes4(EMPTY), "MyCustomWebform");
 		if (error != BaseErrors.NO_ERROR()) return "Error registering WEB application for user task";
 
-		(error, addr) = repository.createProcessModel("testModelUserTasks", "UserTask Test Model", [1,0,0], modelAuthor, false, EMPTY, EMPTY);
+		(error, addr) = repository.createProcessModel("testModelUserTasks", "UserTask Test Model", [1,0,0], modelAuthor, false, dummyModelFileReference);
 		if (addr == 0x0) return "Unable to create a ProcessModel";
 		ProcessModel pm = ProcessModel(addr);
 
@@ -1375,7 +1376,7 @@ contract BpmServiceTest {
 
 		UserAccount user1 = new DefaultUserAccount(this, 0x0);
 	
-		(error, addr) = repository.createProcessModel("testModelAbort", "Abort Test Model", [1,0,0], modelAuthor, false, EMPTY, EMPTY);
+		(error, addr) = repository.createProcessModel("testModelAbort", "Abort Test Model", [1,0,0], modelAuthor, false, dummyModelFileReference);
 		if (addr == 0x0) return "Unable to create a ProcessModel";
 		ProcessModel pm = ProcessModel(addr);
 
@@ -1459,7 +1460,7 @@ contract BpmServiceTest {
 		signatories[1] = address(user2);
 		dataStorage.setDataValueAsAddressArray("SIGNATORIES", signatories);
 
-		(error, addr) = repository.createProcessModel("multiInstanceUserTasks", "Multi Instance User Tasks", [1,0,0], modelAuthor, false, EMPTY, EMPTY);
+		(error, addr) = repository.createProcessModel("multiInstanceUserTasks", "Multi Instance User Tasks", [1,0,0], modelAuthor, false, dummyModelFileReference);
 		if (addr == 0x0) return "Unable to create a ProcessModel";
 		ProcessModel pm = ProcessModel(addr);
 
@@ -1547,12 +1548,12 @@ contract BpmServiceTest {
 		service.setApplicationRegistry(applicationRegistry);
 
 		// Two process models
-		(error, addr) = repository.createProcessModel("ModelA", "Model A", [1,0,0], modelAuthor, false, EMPTY, EMPTY);
+		(error, addr) = repository.createProcessModel("ModelA", "Model A", [1,0,0], modelAuthor, false, dummyModelFileReference);
 		if (addr == 0x0) return "Unable to create ProcessModel A";
 		ProcessModel pmA = ProcessModel(addr);
 		pmA.addParticipant(participantId1, address(this), EMPTY, EMPTY, 0x0);
 
-		(error, addr) = repository.createProcessModel("ModelB", "Model B", [1,0,0], modelAuthor, false, EMPTY, EMPTY);
+		(error, addr) = repository.createProcessModel("ModelB", "Model B", [1,0,0], modelAuthor, false, dummyModelFileReference);
 		if (addr == 0x0) return "Unable to create ProcessModel B";
 		ProcessModel pmB = ProcessModel(addr);
 

--- a/contracts/src/commons-management/test/ContractManagerTest.sol
+++ b/contracts/src/commons-management/test/ContractManagerTest.sol
@@ -90,7 +90,7 @@ contract ContractManagerTest {
  */
 contract DefaultTestService is Versioned, AbstractDbUpgradeable {
 
-    constructor(uint8[3] _version) Versioned(_version[0], _version[1], _version[2]) {
+    constructor(uint8[3] _version) Versioned(_version[0], _version[1], _version[2]) public {
 
     }
 

--- a/contracts/src/documents-commons/Documents.sol
+++ b/contracts/src/documents-commons/Documents.sol
@@ -8,9 +8,9 @@ library Documents {
 
 	// enum State {DRAFT, FINAL, EFFECTIVE, CANCELED}
 
-	struct HoardGrant {
-		bytes32 hoardAddress;
-		bytes32 secretKey;
+	struct DocumentReference {
+		string reference;
+		bool exists;
 	}
 
 	struct DocumentVersion {


### PR DESCRIPTION
This PR replaces all usage of two bytes32 fields to store file references with a single string.

NOTE: this is a breaking change as function names, event parameters, and some Vent columns have been renamed in this refactoring.